### PR TITLE
feat: T012 core logging implementation

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -82,11 +82,11 @@ tasks:
   description: ログ基盤を用意（最低限）
   acceptance_criteria:
     - "pytest caplog で JSON 文字列が出力され、level/name/message を含む"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-08-30"
+  end: "2025-08-30"
+  notes: "JSON logging configured"
 
 - id: T013
   title: core.cors の実装

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -1,0 +1,47 @@
+"""Utility functions for application logging.
+
+This module provides a simple ``configure_logging`` helper that configures the
+root logger to output JSON formatted log records. Only a minimal set of fields
+``level``, ``name`` and ``message`` are included to satisfy the project
+requirements.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+
+class _JsonFormatter(logging.Formatter):
+    """Format log records as compact JSON strings."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - short
+        return json.dumps(
+            {
+                "level": record.levelname,
+                "name": record.name,
+                "message": record.getMessage(),
+            }
+        )
+
+
+def configure_logging(level: int | str = logging.INFO) -> None:
+    """Configure the root logger to emit JSON formatted records.
+
+    Parameters
+    ----------
+    level:
+        The minimum logging level. Defaults to ``logging.INFO``.
+    """
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(_JsonFormatter())
+
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level)
+
+
+__all__ = ["configure_logging"]
+

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,22 @@
+import json
+import logging
+
+from app.core.logging import configure_logging
+
+
+def test_configure_logging_outputs_json(caplog):
+    """Logs should be formatted as JSON containing level, name and message."""
+
+    configure_logging()
+    logging.getLogger().addHandler(caplog.handler)
+    caplog.set_level(logging.INFO)
+    logging.getLogger("test").info("hello")
+
+    record = caplog.records[0]
+    formatter = logging.getLogger().handlers[0].formatter
+    log_line = formatter.format(record)
+    data = json.loads(log_line)
+    assert data["level"] == "INFO"
+    assert data["name"] == "test"
+    assert data["message"] == "hello"
+


### PR DESCRIPTION
## Summary
- implement JSON-based logging configuration
- verify logging outputs level, name and message in JSON
- update master task list for T012

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b09734335883289769a243ea545f53