### PR TITLE
feat: T013 core.cors の実装

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -97,11 +97,11 @@ tasks:
   description: CORS 設定（許可オリジンCSV→配列）
   acceptance_criteria:
     - "空文字ならCORS無効、値があれば許可オリジンが設定されるユニットテスト"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-08-31"
+  end: "2025-08-31"
+  notes: "CORS middleware implemented"
 
 # ========= 2. DB 接続・モデル =========
 - id: T020

--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -1,0 +1,45 @@
+"""Utilities for creating a CORS middleware based on settings."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, Type
+
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.core.config import Settings
+
+
+MiddlewareConfig = Tuple[Type[CORSMiddleware], dict]
+
+
+def create_cors_middleware(settings: Settings) -> Optional[MiddlewareConfig]:
+    """Return a ``CORSMiddleware`` configuration if origins are provided.
+
+    Parameters
+    ----------
+    settings:
+        The application settings containing the ``CORS_ALLOW_ORIGINS`` CSV.
+
+    Returns
+    -------
+    Optional[MiddlewareConfig]
+        ``None`` if no origins were provided, otherwise a tuple of the
+        middleware class and keyword arguments to pass to ``add_middleware``.
+    """
+
+    if not settings.CORS_ALLOW_ORIGINS:
+        return None
+
+    origins = [o.strip() for o in settings.CORS_ALLOW_ORIGINS.split(",") if o.strip()]
+    return (
+        CORSMiddleware,
+        {
+            "allow_origins": origins,
+            "allow_credentials": True,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        },
+    )
+
+
+__all__ = ["create_cors_middleware"]

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,0 +1,17 @@
+from app.core.config import Settings
+from app.core.cors import create_cors_middleware
+from fastapi.middleware.cors import CORSMiddleware
+
+
+def test_cors_middleware_disabled_when_origins_empty():
+    settings = Settings(CORS_ALLOW_ORIGINS="")
+    assert create_cors_middleware(settings) is None
+
+
+def test_cors_middleware_enabled_with_origins():
+    settings = Settings(CORS_ALLOW_ORIGINS="https://a.com, https://b.com")
+    middleware = create_cors_middleware(settings)
+    assert middleware is not None
+    cls, options = middleware
+    assert cls is CORSMiddleware
+    assert options["allow_origins"] == ["https://a.com", "https://b.com"]


### PR DESCRIPTION
## Summary
- implement CORS middleware factory that parses `CORS_ALLOW_ORIGINS`
- add unit tests ensuring middleware disabled with empty setting and configured otherwise
- mark T013 as done in Master Task List

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0994641cc8328bd432963acc7e1a6