### PR TITLE
feat: T021 db models

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -135,11 +135,11 @@ tasks:
     - "CHECK(高値/安値/前後関係) 定義済"
     - "symbol_changes: UNIQUE(new_symbol) と PK(old_symbol, change_date)"
     - "PostgreSQL方言へDDLコンパイル文字列にPK/FK/CHECKが含まれることをテスト"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-02"
+  end: "2025-09-02"
+  notes: "SQLAlchemy models with constraints added"
 
 # ========= 3. Alembic =========
 - id: T030

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+"""SQLAlchemy declarative base for ORM models."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for declarative models."""
+    pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Database models for core tables."""
+
+import sqlalchemy as sa
+from sqlalchemy import Index
+
+from .base import Base
+
+
+class Symbol(Base):
+    """Tradable symbols metadata."""
+
+    __tablename__ = "symbols"
+
+    symbol = sa.Column(sa.String, primary_key=True)
+    name = sa.Column(sa.String, nullable=True)
+    exchange = sa.Column(sa.String, nullable=True)
+    currency = sa.Column(sa.String(3), nullable=True)
+    is_active = sa.Column(sa.Boolean, nullable=True)
+    first_date = sa.Column(sa.Date, nullable=True)
+    last_date = sa.Column(sa.Date, nullable=True)
+
+
+class SymbolChange(Base):
+    """Mapping of symbol changes (one hop)."""
+
+    __tablename__ = "symbol_changes"
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("old_symbol", "change_date"),
+        sa.UniqueConstraint("new_symbol"),
+        Index("idx_symbol_changes_old", "old_symbol"),
+        Index("idx_symbol_changes_new", "new_symbol"),
+    )
+
+    old_symbol = sa.Column(sa.String, nullable=False)
+    new_symbol = sa.Column(sa.String, nullable=False)
+    change_date = sa.Column(sa.Date, nullable=False)
+    reason = sa.Column(sa.String, nullable=True)
+
+
+class Price(Base):
+    """Daily adjusted OHLCV prices."""
+
+    __tablename__ = "prices"
+    __table_args__ = (
+        sa.PrimaryKeyConstraint("symbol", "date"),
+        sa.ForeignKeyConstraint(
+            ["symbol"], ["symbols.symbol"], onupdate="CASCADE", ondelete="RESTRICT"
+        ),
+        sa.CheckConstraint(
+            "high >= low AND high >= open AND high >= close AND low <= open AND low <= close",
+            name="ck_prices_high_low_range",
+        ),
+        sa.CheckConstraint(
+            "open > 0 AND high > 0 AND low > 0 AND close > 0",
+            name="ck_prices_positive",
+        ),
+    )
+
+    symbol = sa.Column(sa.String, nullable=False)
+    date = sa.Column(sa.Date, nullable=False)
+    open = sa.Column(sa.Float, nullable=False)
+    high = sa.Column(sa.Float, nullable=False)
+    low = sa.Column(sa.Float, nullable=False)
+    close = sa.Column(sa.Float, nullable=False)
+    volume = sa.Column(sa.BigInteger, nullable=False)
+    source = sa.Column(sa.String, nullable=False)
+    last_updated = sa.Column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateTable
+
+from app.db import models
+
+
+def compile_ddl(table: sa.Table) -> str:
+    return str(CreateTable(table).compile(dialect=postgresql.dialect()))
+
+
+def test_prices_table_ddl_contains_constraints():
+    ddl = compile_ddl(models.Price.__table__)
+    assert "PRIMARY KEY (symbol, date)" in ddl
+    assert "FOREIGN KEY" in ddl and "REFERENCES symbols (symbol)" in ddl
+    assert "ON UPDATE CASCADE" in ddl and "ON DELETE RESTRICT" in ddl
+    assert (
+        "CHECK (high >= low AND high >= open AND high >= close AND low <= open AND low <= close)"
+        in ddl
+    )
+    assert "CHECK (open > 0 AND high > 0 AND low > 0 AND close > 0)" in ddl
+    assert isinstance(models.Price.__table__.c.volume.type, sa.BigInteger)
+    assert models.Price.__table__.c.last_updated.type.timezone is True
+
+
+def test_symbol_changes_constraints():
+    ddl = compile_ddl(models.SymbolChange.__table__)
+    assert "UNIQUE (new_symbol)" in ddl
+    assert "PRIMARY KEY (old_symbol, change_date)" in ddl


### PR DESCRIPTION
## Summary
- add SQLAlchemy base and core table models
- verify PK/FK/CHECK constraints via DDL compilation tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ee50c74083288abc53df402bac25