### PR TITLE
feat: T031 initial schema migration

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -171,11 +171,11 @@ tasks:
   acceptance_criteria:
     - "マイグレーションスクリプトに create_table('symbols'), create_table('symbol_changes'), create_table('prices') が存在"
     - "UNIQUE(new_symbol), CHECK群 がマイグレーションに明示"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-04"
+  end: "2025-09-04"
+  notes: "Initial schema migration added"
 
 - id: T032
   title: 002_fn_prices_resolved マイグレーション（SQL関数）

--- a/app/migrations/versions/001_init.py
+++ b/app/migrations/versions/001_init.py
@@ -1,0 +1,69 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "001_init"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "symbols",
+        sa.Column("symbol", sa.String(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("exchange", sa.String(), nullable=True),
+        sa.Column("currency", sa.String(3), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=True),
+        sa.Column("first_date", sa.Date(), nullable=True),
+        sa.Column("last_date", sa.Date(), nullable=True),
+    )
+
+    op.create_table(
+        "symbol_changes",
+        sa.Column("old_symbol", sa.String(), nullable=False),
+        sa.Column("new_symbol", sa.String(), nullable=False),
+        sa.Column("change_date", sa.Date(), nullable=False),
+        sa.Column("reason", sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint("old_symbol", "change_date"),
+        sa.UniqueConstraint("new_symbol"),
+        sa.Index("idx_symbol_changes_old", "old_symbol"),
+        sa.Index("idx_symbol_changes_new", "new_symbol"),
+    )
+
+    op.create_table(
+        "prices",
+        sa.Column("symbol", sa.String(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("open", sa.Float(), nullable=False),
+        sa.Column("high", sa.Float(), nullable=False),
+        sa.Column("low", sa.Float(), nullable=False),
+        sa.Column("close", sa.Float(), nullable=False),
+        sa.Column("volume", sa.BigInteger(), nullable=False),
+        sa.Column("source", sa.String(), nullable=False),
+        sa.Column(
+            "last_updated",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("symbol", "date"),
+        sa.ForeignKeyConstraint(
+            ["symbol"], ["symbols.symbol"], onupdate="CASCADE", ondelete="RESTRICT"
+        ),
+        sa.CheckConstraint(
+            "high >= low AND high >= open AND high >= close AND low <= open AND low <= close",
+            name="ck_prices_high_low_range",
+        ),
+        sa.CheckConstraint(
+            "open > 0 AND high > 0 AND low > 0 AND close > 0",
+            name="ck_prices_positive",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("prices")
+    op.drop_table("symbol_changes")
+    op.drop_table("symbols")

--- a/tests/unit/test_migration_init.py
+++ b/tests/unit/test_migration_init.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+MIGRATION = Path("app/migrations/versions/001_init.py")
+
+
+def test_migration_contains_tables_and_constraints():
+    content = MIGRATION.read_text()
+    assert "op.create_table(\n        \"symbols\"" in content
+    assert "op.create_table(\n        \"symbol_changes\"" in content
+    assert "op.create_table(\n        \"prices\"" in content
+    assert "sa.UniqueConstraint(\"new_symbol\")" in content
+    assert "ck_prices_high_low_range" in content
+    assert "ck_prices_positive" in content


### PR DESCRIPTION
## Summary
- add initial Alembic migration for symbols, symbol_changes, and prices tables
- cover migration with unit test
- record progress in master task list

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0f9bc097483288abdead2cbea0a60