### PR TITLE
feat: add prices resolved function migration (T032)

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -187,11 +187,11 @@ tasks:
   acceptance_criteria:
     - "スクリプト内に 'CREATE OR REPLACE FUNCTION get_prices_resolved' 文字列がある"
     - "ロールバックで DROP FUNCTION がある"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-05"
+  end: "2025-09-05"
+  notes: "Function migration added"
 
 # ========= 4. スキーマ & 依存注入 =========
 - id: T040

--- a/app/migrations/versions/002_fn_prices_resolved.py
+++ b/app/migrations/versions/002_fn_prices_resolved.py
@@ -1,0 +1,72 @@
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "002_fn_prices_resolved"
+down_revision = "001_init"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION get_prices_resolved(
+            _symbol text,
+            _from date,
+            _to date
+        )
+        RETURNS TABLE (
+            symbol text,
+            source_symbol text,
+            date date,
+            open double precision,
+            high double precision,
+            low double precision,
+            close double precision,
+            volume bigint,
+            source text,
+            last_updated timestamptz
+        )
+        LANGUAGE SQL
+        AS $$
+            SELECT
+                _symbol AS symbol,
+                p.symbol AS source_symbol,
+                p.date,
+                p.open,
+                p.high,
+                p.low,
+                p.close,
+                p.volume,
+                p.source,
+                p.last_updated
+            FROM prices p
+            WHERE p.symbol = _symbol
+              AND p.date BETWEEN _from AND _to
+            UNION ALL
+            SELECT
+                _symbol AS symbol,
+                p.symbol AS source_symbol,
+                p.date,
+                p.open,
+                p.high,
+                p.low,
+                p.close,
+                p.volume,
+                p.source,
+                p.last_updated
+            FROM symbol_changes sc
+            JOIN prices p
+              ON p.symbol = sc.old_symbol
+             AND p.date < sc.change_date
+            WHERE sc.new_symbol = _symbol
+              AND p.date BETWEEN _from AND _to
+            ORDER BY date
+        $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP FUNCTION IF EXISTS get_prices_resolved(text, date, date);")

--- a/tests/unit/test_migration_fn_prices_resolved.py
+++ b/tests/unit/test_migration_fn_prices_resolved.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+MIGRATION = Path("app/migrations/versions/002_fn_prices_resolved.py")
+
+
+def test_migration_contains_create_and_drop_function():
+    content = MIGRATION.read_text()
+    assert "CREATE OR REPLACE FUNCTION get_prices_resolved" in content
+    assert "DROP FUNCTION IF EXISTS get_prices_resolved" in content


### PR DESCRIPTION
## Summary
- add Alembic migration for `get_prices_resolved`
- test migration for create/drop markers
- update task status for T032

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0fe36e2888328b66d29edc5870a06