### PR TITLE
fix: make lifespan async; expose settings singleton; handle CORS wildcard safely

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,7 +17,14 @@ class Settings(BaseSettings):
     CORS_ALLOW_ORIGINS: str = ""
     LOG_LEVEL: str = "INFO"
 
-    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
 
-__all__ = ["Settings"]
+# Expose a module-level singleton for convenient import across the app.
+# Usage: ``from app.core.config import settings``
+settings = Settings()
+
+
+__all__ = ["Settings", "settings"]

--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -2,44 +2,56 @@
 
 from __future__ import annotations
 
-from typing import Optional, Tuple, Type
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import Settings
 
 
-MiddlewareConfig = Tuple[Type[CORSMiddleware], dict]
+MiddlewareConfig = Tuple[Type[CORSMiddleware], Dict[str, Any]]
+
+
+def _parse_csv(csv: str) -> List[str]:
+    """Split a comma-separated string into trimmed items, omitting empties."""
+    return [s.strip() for s in csv.split(",") if s and s.strip()]
 
 
 def create_cors_middleware(settings: Settings) -> Optional[MiddlewareConfig]:
-    """Return a ``CORSMiddleware`` configuration if origins are provided.
+    """Return a ``CORSMiddleware`` configuration if CORS is enabled.
 
-    Parameters
-    ----------
-    settings:
-        The application settings containing the ``CORS_ALLOW_ORIGINS`` CSV.
-
-    Returns
-    -------
-    Optional[MiddlewareConfig]
-        ``None`` if no origins were provided, otherwise a tuple of the
-        middleware class and keyword arguments to pass to ``add_middleware``.
+    Handles the wildcard "*" value safely by switching to ``allow_origin_regex``
+    and disabling credentials, as Starlette forbids credentials when using a
+    raw "*" origin list.
     """
-
-    if not settings.CORS_ALLOW_ORIGINS:
+    csv = (settings.CORS_ALLOW_ORIGINS or "").strip()
+    if not csv:
         return None
 
-    origins = [o.strip() for o in settings.CORS_ALLOW_ORIGINS.split(",") if o.strip()]
-    return (
-        CORSMiddleware,
-        {
+    origins = _parse_csv(csv)
+    kwargs: Dict[str, Any] = {
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+        # Expose request ID header for tracing
+        "expose_headers": ["X-Request-ID"],
+    }
+
+    wildcard_only = len(origins) == 1 and origins[0] == "*"
+    wildcard_included = "*" in origins
+
+    if wildcard_only or wildcard_included:
+        # Starlette does not allow allow_credentials=True with wildcard
+        kwargs.update({
+            "allow_origin_regex": ".*",
+            "allow_credentials": False,
+        })
+    else:
+        kwargs.update({
             "allow_origins": origins,
             "allow_credentials": True,
-            "allow_methods": ["*"],
-            "allow_headers": ["*"],
-        },
-    )
+        })
+
+    return CORSMiddleware, kwargs
 
 
 __all__ = ["create_cors_middleware"]

--- a/app/main.py
+++ b/app/main.py
@@ -4,9 +4,20 @@ from fastapi import FastAPI
 
 
 @asynccontextmanager
-def lifespan(_: FastAPI):
-    """Placeholder lifespan for future DB setup."""
-    yield
+async def lifespan(_: FastAPI):
+    """Placeholder lifespan for future DB setup.
+
+    FastAPI requires an *asynchronous* generator when using
+    ``@asynccontextmanager``. Returning a synchronous generator causes
+    ``AttributeError('__anext__')`` during application startup. This async
+    variant ensures compatibility.
+    """
+    try:
+        # Startup hooks (e.g., schedule DB initialisation) would go here.
+        yield
+    finally:
+        # Shutdown hooks (cleanup resources) would go here.
+        pass
 
 
 app = FastAPI(lifespan=lifespan)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,4 @@
-from app.core.config import Settings
+from app.core.config import Settings, settings
 
 
 def test_settings_env_override(monkeypatch):
@@ -22,3 +22,10 @@ def test_settings_contains_all_keys():
         "LOG_LEVEL",
     }
     assert expected_keys <= settings.model_dump().keys()
+
+
+def test_module_level_settings_singleton():
+    """Ensure the module-level `settings` object is initialised and usable."""
+    assert isinstance(settings, Settings)
+    # accessing an attribute verifies the object is populated
+    assert settings.APP_ENV == "development"

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -15,3 +15,14 @@ def test_cors_middleware_enabled_with_origins():
     cls, options = middleware
     assert cls is CORSMiddleware
     assert options["allow_origins"] == ["https://a.com", "https://b.com"]
+    assert options["allow_credentials"] is True
+
+
+def test_cors_middleware_wildcard_disables_credentials_and_uses_regex():
+    settings = Settings(CORS_ALLOW_ORIGINS="*")
+    middleware = create_cors_middleware(settings)
+    assert middleware is not None
+    cls, options = middleware
+    assert cls is CORSMiddleware
+    assert options["allow_origin_regex"] == ".*"
+    assert options["allow_credentials"] is False


### PR DESCRIPTION
## Summary
- make FastAPI lifespan an async generator to avoid startup errors
- expose module-level `settings` singleton for easy importing
- handle CORS_ALLOW_ORIGINS="*" by using regex and disabling credentials

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10686e0848328b4b6d2b8dae82dcc