### PR TITLE
feat/T040 add pydantic schemas

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -210,11 +210,11 @@ tasks:
   acceptance_criteria:
     - "無効な日付レンジは ValidationError"
     - "PriceRowOut.date は date 型、last_updated は datetime(timezone) 型"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-06"
+  end: "2025-09-06"
+  notes: "Pydantic schemas implemented"
 
 - id: T041
   title: api.deps（依存注入）

--- a/app/schemas/common.py
+++ b/app/schemas/common.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+
+class DateRange(BaseModel):
+    """A validated date range."""
+
+    from_: date = Field(..., alias="from")
+    to: date
+
+    # allow population by both field name and alias
+    model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("to")
+    @classmethod
+    def _check_order(cls, v: date, info: ValidationInfo) -> date:
+        start = info.data.get("from_") if info.data else None
+        if start and v < start:
+            raise ValueError("'from' must be on or before 'to'")
+        return v
+
+
+__all__ = ["DateRange"]

--- a/app/schemas/metrics.py
+++ b/app/schemas/metrics.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class MetricsOut(BaseModel):
+    """Output schema for computed metrics."""
+
+    symbol: str
+    cagr: float
+    stdev: float
+    max_drawdown: float
+    n_days: int
+
+
+__all__ = ["MetricsOut"]

--- a/app/schemas/prices.py
+++ b/app/schemas/prices.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PriceRowOut(BaseModel):
+    """Output schema for a price row."""
+
+    symbol: str
+    date: date
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+    source: str
+    last_updated: datetime = Field(..., description="Timezone-aware timestamp")
+    source_symbol: str | None = None
+
+    @field_validator("last_updated")
+    @classmethod
+    def _ensure_tz(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("last_updated must be timezone-aware")
+        return v
+
+
+__all__ = ["PriceRowOut"]

--- a/app/schemas/symbols.py
+++ b/app/schemas/symbols.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel
+
+
+class SymbolOut(BaseModel):
+    """Output schema for symbol information."""
+
+    symbol: str
+    name: str | None = None
+    exchange: str | None = None
+    currency: str | None = None
+    is_active: bool | None = None
+    first_date: date | None = None
+    last_date: date | None = None
+
+
+__all__ = ["SymbolOut"]

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,42 @@
+from datetime import date, datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.common import DateRange
+from app.schemas.prices import PriceRowOut
+
+
+def test_date_range_invalid_order_raises():
+    with pytest.raises(ValidationError):
+        DateRange(from_=date(2023, 1, 10), to=date(2023, 1, 5))
+
+
+def test_price_row_out_enforces_types():
+    aware = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    row = PriceRowOut(
+        symbol="AAA",
+        date=date(2024, 1, 1),
+        open=1.0,
+        high=2.0,
+        low=0.5,
+        close=1.5,
+        volume=100,
+        source="test",
+        last_updated=aware,
+    )
+    assert isinstance(row.date, date)
+    assert row.last_updated.tzinfo is not None
+
+    with pytest.raises(ValidationError):
+        PriceRowOut(
+            symbol="AAA",
+            date=date(2024, 1, 1),
+            open=1.0,
+            high=2.0,
+            low=0.5,
+            close=1.5,
+            volume=100,
+            source="test",
+            last_updated=datetime(2024, 1, 1),  # naive
+        )


### PR DESCRIPTION
## Summary
- implement DateRange, PriceRowOut, MetricsOut, SymbolOut schemas
- add unit tests for date range validation and timezone-aware prices

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b10c0e08cc832899b403da7aad100f