### PR TITLE
feat/T050 symbol normalization service

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -243,11 +243,11 @@ tasks:
   description: 入出力の前処理
   acceptance_criteria:
     - "brk.b -> BRK-B, 7203.T -> 7203.T を満たす"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-08"
+  end: "2025-09-08"
+  notes: "Symbol normalization implemented"
 
 - id: T051
   title: services.resolver（1ホップ区間分割）

--- a/app/services/normalize.py
+++ b/app/services/normalize.py
@@ -1,0 +1,18 @@
+"""Symbol normalization utilities."""
+
+from __future__ import annotations
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Normalize ticker symbols to Yahoo Finance style.
+
+    - Uppercase the symbol.
+    - Convert share-class separator from "." to "-" when the prefix is alphabetic.
+    - Preserve exchange suffixes (e.g., ".T").
+    """
+    normalized = symbol.strip().upper()
+    if "." in normalized:
+        prefix, suffix = normalized.split(".", 1)
+        if prefix.isalpha():
+            normalized = f"{prefix}-{suffix}"
+    return normalized

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,15 @@
+import pytest
+
+from app.services.normalize import normalize_symbol
+
+
+@pytest.mark.parametrize(
+    "inp,expected",
+    [
+        ("brk.b", "BRK-B"),
+        ("BRK.B", "BRK-B"),
+        ("7203.T", "7203.T"),
+    ],
+)
+def test_normalize_symbol(inp, expected):
+    assert normalize_symbol(inp) == expected


### PR DESCRIPTION
## Summary
- add `normalize_symbol` to standardize ticker formats
- cover BRK.B and exchange-suffixed tickers with unit tests
- mark T050 as done in Master Task List

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11253b8288328b9df2c6cc88c5389