### PR TITLE
feat/T051-resolver

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -260,11 +260,11 @@ tasks:
   description: API/取得双方で使う区間分割ロジック（DB不要で純粋関数）
   acceptance_criteria:
     - "change_date当日以降を新、前日までを旧と判定"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-09"
+  end: "2025-09-09"
+  notes: "1-hop resolver implemented"
 
 - id: T052
   title: services.metrics（CAGR/STDEV/MaxDD）

--- a/app/services/resolver.py
+++ b/app/services/resolver.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Iterable, List, Tuple, Any
+
+
+def _get(row: Any, key: str):
+    try:
+        return getattr(row, key)
+    except AttributeError:
+        return row[key]
+
+
+def segments_for(
+    symbol: str,
+    date_from: date,
+    date_to: date,
+    symbol_changes_rows: Iterable[Any],
+) -> List[Tuple[str, date, date]]:
+    """Return symbol segments accounting for a single ticker change.
+
+    Parameters
+    ----------
+    symbol: str
+        Requested symbol (either old or new).
+    date_from: date
+        Start date, inclusive.
+    date_to: date
+        End date, inclusive.
+    symbol_changes_rows: iterable
+        Rows/dicts having ``old_symbol``, ``new_symbol`` and ``change_date``.
+
+    Returns
+    -------
+    list of tuples ``(actual_symbol, seg_from, seg_to)`` covering the
+    requested range.  ``change_date`` itself belongs to the new symbol while
+    the day before remains the old symbol.
+    """
+    change_row = None
+    for row in symbol_changes_rows:
+        old = _get(row, "old_symbol")
+        new = _get(row, "new_symbol")
+        change = _get(row, "change_date")
+        if symbol == old or symbol == new:
+            change_row = (old, new, change)
+            break
+
+    if not change_row:
+        return [(symbol, date_from, date_to)]
+
+    old, new, change_date = change_row
+
+    if date_to < change_date:
+        return [(old, date_from, date_to)]
+
+    if date_from >= change_date:
+        return [(new, date_from, date_to)]
+
+    pre_end = change_date - timedelta(days=1)
+    return [(old, date_from, pre_end), (new, change_date, date_to)]

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,0 +1,25 @@
+from datetime import date
+
+from app.services.resolver import segments_for
+
+
+def test_segments_for_handles_symbol_change_boundary():
+    rows = [
+        {"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}
+    ]
+    result = segments_for("FB", date(2022, 6, 8), date(2022, 6, 10), rows)
+    assert result == [
+        ("FB", date(2022, 6, 8), date(2022, 6, 8)),
+        ("META", date(2022, 6, 9), date(2022, 6, 10)),
+    ]
+
+
+def test_segments_for_accepts_new_symbol_request():
+    rows = [
+        {"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}
+    ]
+    result = segments_for("META", date(2022, 6, 8), date(2022, 6, 10), rows)
+    assert result == [
+        ("FB", date(2022, 6, 8), date(2022, 6, 8)),
+        ("META", date(2022, 6, 9), date(2022, 6, 10)),
+    ]


### PR DESCRIPTION
## Summary
- add 1-hop symbol resolver to split ranges at ticker change
- cover FB→META boundary cases with unit tests
- update task list for T051

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `PYTHONPATH=. pytest tests/unit/test_resolver.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1152f26b88328a32e9c1337943a17