### PR TITLE
feat/T052-metrics

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -279,11 +279,11 @@ tasks:
     - "CAGR = exp(sum(r)*252/N)-1"
     - "STDEV = std(r, ddof=1)*sqrt(252)"
     - "MaxDD 計算が既知事例で一致"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-10"
+  end: "2025-09-10"
+  notes: "Metrics calculation implemented"
 
 - id: T053
   title: services.upsert（DataFrame→UPSERT 準備）

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,0 +1,55 @@
+from typing import Any, Dict, List
+import pandas as pd
+
+
+def compute_metrics(price_frames: Dict[str, pd.DataFrame]) -> List[dict[str, Any]]:
+    import numpy as np
+
+    """Compute financial metrics for provided price data.
+
+    Each DataFrame must contain an ``adj_close`` column indexed by date.
+    The function calculates daily log returns and derives annualised metrics
+    using the formulas:
+
+    - ``CAGR = exp(sum(r) * 252 / N) - 1``
+    - ``STDEV = std(r, ddof=1) * sqrt(252)``
+    - ``MaxDD = min(exp(cum_r - cum_r.cummax()) - 1)``
+    """
+    results: List[dict[str, Any]] = []
+
+    for symbol, df in price_frames.items():
+        prices = df["adj_close"].dropna().astype(float)
+        log_ret = np.log(prices / prices.shift(1)).dropna()
+        n = len(log_ret)
+        if n == 0:
+            results.append(
+                {
+                    "symbol": symbol,
+                    "cagr": 0.0,
+                    "stdev": 0.0,
+                    "max_drawdown": 0.0,
+                    "n_days": 0,
+                }
+            )
+            continue
+
+        cagr = float(np.exp(log_ret.sum() * 252 / n) - 1)
+        stdev = float(log_ret.std(ddof=1) * np.sqrt(252))
+        cum_r = log_ret.cumsum()
+        drawdowns = np.exp(cum_r - cum_r.cummax()) - 1
+        max_dd = float(drawdowns.min())
+
+        results.append(
+            {
+                "symbol": symbol,
+                "cagr": cagr,
+                "stdev": stdev,
+                "max_drawdown": max_dd,
+                "n_days": n,
+            }
+        )
+
+    return results
+
+
+__all__ = ["compute_metrics"]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from app.services.metrics import compute_metrics
+
+
+def test_compute_metrics_formulas():
+    dates = pd.date_range('2020-01-01', periods=4, freq='D')
+    prices = pd.DataFrame({'adj_close': [100, 120, 80, 90]}, index=dates)
+    result = compute_metrics({'AAA': prices})[0]
+
+    log_ret = np.log(prices['adj_close'] / prices['adj_close'].shift(1)).dropna()
+    n = len(log_ret)
+    expected_cagr = np.exp(log_ret.sum() * 252 / n) - 1
+    expected_stdev = log_ret.std(ddof=1) * np.sqrt(252)
+    cum_r = log_ret.cumsum()
+    expected_maxdd = (np.exp(cum_r - cum_r.cummax()) - 1).min()
+
+    assert result['symbol'] == 'AAA'
+    assert result['n_days'] == n
+    assert result['cagr'] == pytest.approx(expected_cagr)
+    assert result['stdev'] == pytest.approx(expected_stdev)
+    assert result['max_drawdown'] == pytest.approx(expected_maxdd)


### PR DESCRIPTION
## Summary
- implement compute_metrics service computing CAGR, annualized volatility, and max drawdown
- add unit test validating formulas with sample price series
- update Master Task List for T052 completion

## Testing
- `.venv/bin/python -m pytest tests/unit/test_metrics.py -q`
- `.venv/bin/python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68b11716ce14832899d3394b989bc5e4