### PR TITLE
fix(normalize,deps,migration): preserve exchange suffixes; use shared settings; guard new-ticker rows

### DIFF
--- a/app/migrations/versions/002_fn_prices_resolved.py
+++ b/app/migrations/versions/002_fn_prices_resolved.py
@@ -1,6 +1,5 @@
 from alembic import op
 
-
 # revision identifiers, used by Alembic.
 revision = "002_fn_prices_resolved"
 down_revision = "001_init"
@@ -11,58 +10,61 @@ depends_on = None
 def upgrade() -> None:
     op.execute(
         """
-        CREATE OR REPLACE FUNCTION get_prices_resolved(
-            _symbol text,
-            _from date,
-            _to date
-        )
+        CREATE OR REPLACE FUNCTION get_prices_resolved(_symbol text, _from date, _to date)
         RETURNS TABLE (
             symbol text,
-            source_symbol text,
             date date,
-            open double precision,
-            high double precision,
-            low double precision,
-            close double precision,
+            open numeric,
+            high numeric,
+            low numeric,
+            close numeric,
             volume bigint,
             source text,
-            last_updated timestamptz
+            last_updated timestamptz,
+            source_symbol text
         )
-        LANGUAGE SQL
+        LANGUAGE sql
         AS $$
-            SELECT
-                _symbol AS symbol,
-                p.symbol AS source_symbol,
-                p.date,
-                p.open,
-                p.high,
-                p.low,
-                p.close,
-                p.volume,
-                p.source,
-                p.last_updated
-            FROM prices p
-            WHERE p.symbol = _symbol
-              AND p.date BETWEEN _from AND _to
-            UNION ALL
-            SELECT
-                _symbol AS symbol,
-                p.symbol AS source_symbol,
-                p.date,
-                p.open,
-                p.high,
-                p.low,
-                p.close,
-                p.volume,
-                p.source,
-                p.last_updated
-            FROM symbol_changes sc
-            JOIN prices p
-              ON p.symbol = sc.old_symbol
-             AND p.date < sc.change_date
-            WHERE sc.new_symbol = _symbol
-              AND p.date BETWEEN _from AND _to
-            ORDER BY date
+        WITH sc AS (
+            SELECT old_symbol, new_symbol, change_date
+              FROM symbol_changes
+             WHERE new_symbol = _symbol
+             LIMIT 1
+        )
+        SELECT p.symbol,
+               p.date,
+               p.open,
+               p.high,
+               p.low,
+               p.close,
+               p.volume,
+               p.source,
+               p.last_updated,
+               NULL::text AS source_symbol
+          FROM prices p
+     LEFT JOIN sc ON TRUE
+         WHERE p.symbol = _symbol
+           AND p.date BETWEEN _from AND _to
+           AND (sc.change_date IS NULL OR p.date >= sc.change_date)
+
+        UNION ALL
+
+        SELECT _symbol AS symbol,
+               p.date,
+               p.open,
+               p.high,
+               p.low,
+               p.close,
+               p.volume,
+               p.source,
+               p.last_updated,
+               p.symbol AS source_symbol
+          FROM prices p
+          JOIN sc ON sc.old_symbol = p.symbol
+         WHERE p.date BETWEEN _from AND _to
+           AND p.date < sc.change_date
+
+         ORDER BY date;
         $$;
         """
     )
@@ -70,3 +72,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("DROP FUNCTION IF EXISTS get_prices_resolved(text, date, date);")
+

--- a/app/services/normalize.py
+++ b/app/services/normalize.py
@@ -2,17 +2,78 @@
 
 from __future__ import annotations
 
+from typing import Optional, Set
 
-def normalize_symbol(symbol: str) -> str:
+_KNOWN_EXCHANGE_SUFFIXES: Set[str] = {
+    # Common Yahoo Finance exchange suffixes (uppercase)
+    # 1-letter codes
+    "T",  # Tokyo
+    "L",  # London
+    "V",  # TSXV
+    "F",  # Frankfurt
+    # 2+ letters
+    "TO",
+    "AX",
+    "DE",
+    "HK",
+    "SW",
+    "MI",
+    "PA",
+    "SA",
+    "SZ",
+    "SS",
+    "TW",
+    "TWO",
+    "BK",
+    "KS",
+    "KQ",
+    "OL",
+    "HE",
+    "ST",
+    "VI",
+    "CO",
+    "AS",
+    "BR",
+    "LS",
+    "IS",
+    "MX",
+    "SI",
+    "JK",
+    "NZ",
+    "JO",
+    "MU",
+    "BE",
+}
+
+
+def normalize_symbol(symbol: Optional[str]) -> str:
     """Normalize ticker symbols to Yahoo Finance style.
 
-    - Uppercase the symbol.
-    - Convert share-class separator from "." to "-" when the prefix is alphabetic.
-    - Preserve exchange suffixes (e.g., ".T").
+    Rules
+    -----
+    * Strip surrounding whitespace and uppercase the symbol.
+    * If the symbol contains a suffix (``."``):
+        - If the suffix is a known exchange code, preserve the ``."``.
+        - Else if the suffix is a single alphabetic character, treat it as a
+          share class and replace the ``."`` with ``-``.
+        - Otherwise, keep the symbol unchanged (e.g., preferred shares with
+          multiple dots).
+    * If ``symbol`` is ``None`` or empty, return an empty string.
     """
-    normalized = symbol.strip().upper()
-    if "." in normalized:
-        prefix, suffix = normalized.split(".", 1)
-        if prefix.isalpha():
-            normalized = f"{prefix}-{suffix}"
-    return normalized
+
+    if not symbol:
+        return ""
+
+    s = symbol.strip().upper()
+    if not s:
+        return ""
+
+    if "." in s:
+        head, tail = s.rsplit(".", 1)
+        if tail in _KNOWN_EXCHANGE_SUFFIXES:
+            return f"{head}.{tail}"
+        if len(tail) == 1 and tail.isalpha():
+            return f"{head}-{tail}"
+        return s
+
+    return s

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -12,7 +12,13 @@ from app.api import deps
 async def test_get_session_dependency(monkeypatch):
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
-    monkeypatch.setattr(deps, "SessionLocal", session_factory)
+
+    def fake_sessionmaker_for(dsn: str):  # pragma: no cover - assertion ensures call
+        assert dsn == "sqlite+aiosqlite:///:memory:"
+        return session_factory
+
+    monkeypatch.setattr(deps, "_sessionmaker_for", fake_sessionmaker_for)
+    monkeypatch.setattr(deps.settings, "DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
     app = FastAPI()
 

--- a/tests/unit/test_migration_fn_prices_resolved.py
+++ b/tests/unit/test_migration_fn_prices_resolved.py
@@ -7,3 +7,5 @@ def test_migration_contains_create_and_drop_function():
     content = MIGRATION.read_text()
     assert "CREATE OR REPLACE FUNCTION get_prices_resolved" in content
     assert "DROP FUNCTION IF EXISTS get_prices_resolved" in content
+    assert "p.date >= sc.change_date" in content
+    assert "p.date < sc.change_date" in content

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -3,13 +3,17 @@ import pytest
 from app.services.normalize import normalize_symbol
 
 
-@pytest.mark.parametrize(
-    "inp,expected",
-    [
-        ("brk.b", "BRK-B"),
-        ("BRK.B", "BRK-B"),
-        ("7203.T", "7203.T"),
-    ],
-)
-def test_normalize_symbol(inp, expected):
-    assert normalize_symbol(inp) == expected
+def test_normalize_stock_class_to_hyphen():
+    assert normalize_symbol("brk.b") == "BRK-B"
+    assert normalize_symbol("RDS.a") == "RDS-A"
+
+
+def test_exchange_suffix_kept_with_dot():
+    assert normalize_symbol("7203.t") == "7203.T"
+    assert normalize_symbol("ry.to") == "RY.TO"
+    assert normalize_symbol("bhp.ax") == "BHP.AX"
+    assert normalize_symbol("azn.l") == "AZN.L"
+
+
+def test_multidot_respected():
+    assert normalize_symbol("ABC.PR.A.TO") == "ABC.PR.A.TO"


### PR DESCRIPTION
## Summary
- refine ticker normalization to retain known exchange suffixes and hyphenate only single-letter classes
- build async sessionmakers per DSN using shared settings and LRU caching
- tighten `get_prices_resolved` to respect `change_date` boundaries and expose `source_symbol`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b119cab7808328acbb1d2cd84a7d03