### PR TITLE
feat: implement upsert helper (T053)

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -297,11 +297,11 @@ tasks:
   acceptance_criteria:
     - "生成SQLに ON CONFLICT (symbol, date) DO UPDATE を含む"
     - "dfのNaNは除去/丸め方針を明確化（テストで確認）"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-11"
+  end: "2025-09-11"
+  notes: "Prepared upsert SQL and row conversion helpers"
 
 - id: T054
   title: services.fetcher（yfinance取得・N日リフレッチ・バックオフ）

--- a/app/services/upsert.py
+++ b/app/services/upsert.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import pandas as pd
+
+
+def df_to_rows(df: pd.DataFrame, *, symbol: str, source: str) -> List[Tuple]:
+    """Convert a price DataFrame into rows for bulk upsert.
+
+    Rows containing NaN values are skipped. Dates are converted to ``date`` and
+    numeric fields are cast to appropriate Python types for insertion.
+    """
+
+    rows: List[Tuple] = []
+    for date, row in df.iterrows():
+        if row.isna().any():
+            continue
+        rows.append(
+            (
+                symbol,
+                date.date(),
+                float(row["open"]),
+                float(row["high"]),
+                float(row["low"]),
+                float(row["close"]),
+                int(row["volume"]),
+                source,
+            )
+        )
+    return rows
+
+
+def upsert_prices_sql() -> str:
+    """Return SQL statement for upserting price rows."""
+
+    return (
+        "INSERT INTO prices (symbol, date, open, high, low, close, volume, source) "
+        "VALUES (:symbol, :date, :open, :high, :low, :close, :volume, :source) "
+        "ON CONFLICT (symbol, date) DO UPDATE SET "
+        "open = EXCLUDED.open, "
+        "high = EXCLUDED.high, "
+        "low = EXCLUDED.low, "
+        "close = EXCLUDED.close, "
+        "volume = EXCLUDED.volume, "
+        "source = EXCLUDED.source, "
+        "last_updated = now();"
+    )
+
+
+__all__ = ["df_to_rows", "upsert_prices_sql"]

--- a/tests/unit/test_upsert.py
+++ b/tests/unit/test_upsert.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from app.services.upsert import df_to_rows, upsert_prices_sql
+
+
+def test_upsert_sql_contains_on_conflict():
+    sql = upsert_prices_sql()
+    assert "ON CONFLICT (symbol, date) DO UPDATE" in sql
+
+
+def test_df_to_rows_drops_nan_and_casts():
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 2.0, None],
+            "high": [1.1, 2.1, 3.1],
+            "low": [0.9, 1.9, 2.9],
+            "close": [1.05, 2.05, 3.05],
+            "volume": [100, 200, 300],
+        },
+        index=pd.to_datetime(["2023-01-01", "2023-01-02", "2023-01-03"]),
+    )
+    rows = df_to_rows(df, symbol="AAPL", source="yfinance")
+    # The row with None open should be dropped
+    assert len(rows) == 2
+    first = rows[0]
+    assert first[0] == "AAPL"
+    assert str(first[1]) == "2023-01-01"
+    assert first[-1] == "yfinance"
+    assert isinstance(first[6], int)


### PR DESCRIPTION
## Summary
- add DataFrame->rows helper and upsert SQL generator for prices
- test upsert logic and SQL string

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b11d7e9f788328a5d54d2a38c32296