### PR TITLE
feat: T054 fetcher service with backoff and refetch

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -315,11 +315,11 @@ tasks:
   acceptance_criteria:
     - "429相当例外時に指数バックオフ（sleepはモック）"
     - "last_date - N 起点での再取得ロジックを関数単体で検証"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-12"
+  end: "2025-09-12"
+  notes: "Fetcher with backoff and refetch logic implemented"
 
 - id: T055
   title: db.utils（アドバイザリロック）

--- a/app/services/fetcher.py
+++ b/app/services/fetcher.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import time
+from datetime import date, timedelta
+from typing import Optional
+from urllib.error import HTTPError
+
+import pandas as pd
+import yfinance as yf
+
+from app.core.config import Settings
+
+
+def fetch_prices(
+    symbol: str,
+    start: date,
+    end: date,
+    *,
+    settings: Settings,
+    last_date: Optional[date] = None,
+) -> pd.DataFrame:
+    """Fetch adjusted OHLCV data for ``symbol`` between ``start`` and ``end``.
+
+    Parameters
+    ----------
+    symbol:
+        Ticker symbol understood by Yahoo Finance.
+    start, end:
+        Date range for the fetch. ``end`` is inclusive.
+    settings:
+        Application settings providing timeout and refetch parameters.
+    last_date:
+        Last date of existing data in the database.  If provided, the fetch will
+        start from ``max(start, last_date - settings.YF_REFETCH_DAYS)`` to
+        re-download the most recent ``N`` days for adjustments.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data frame with columns ``open``, ``high``, ``low``, ``close``,
+        ``volume`` and a ``DatetimeIndex``.
+    """
+
+    fetch_start = start
+    if last_date is not None:
+        refetch_start = last_date - timedelta(days=settings.YF_REFETCH_DAYS)
+        if refetch_start > fetch_start:
+            fetch_start = refetch_start
+
+    attempts = 0
+    delay = 1.0
+    max_attempts = 3
+
+    while True:
+        try:
+            df = yf.download(
+                symbol,
+                start=fetch_start,
+                end=end,
+                auto_adjust=True,
+                progress=False,
+                timeout=settings.FETCH_TIMEOUT_SECONDS,
+            )
+            df = df.rename(
+                columns={
+                    "Open": "open",
+                    "High": "high",
+                    "Low": "low",
+                    "Close": "close",
+                    "Adj Close": "adj_close",
+                    "Volume": "volume",
+                }
+            )
+            if "adj_close" in df.columns:
+                df = df.drop(columns=["adj_close"])
+            return df
+        except HTTPError as exc:  # pragma: no cover - branch executed in tests
+            if getattr(exc, "code", None) in {429, 999} and attempts < max_attempts - 1:
+                time.sleep(delay)
+                delay *= 2
+                attempts += 1
+                continue
+            raise
+
+__all__ = ["fetch_prices"]

--- a/tests/unit/test_fetcher.py
+++ b/tests/unit/test_fetcher.py
@@ -1,0 +1,48 @@
+from datetime import date
+from urllib.error import HTTPError
+
+import pandas as pd
+from app.core.config import Settings
+from app.services.fetcher import fetch_prices
+
+
+def _sample_df():
+    return pd.DataFrame(
+        {
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Volume": [100],
+        },
+        index=pd.to_datetime(["2024-01-01"]),
+    )
+
+
+def test_fetch_prices_backoff(mocker):
+    settings = Settings()
+    download = mocker.patch("app.services.fetcher.yf.download")
+    sleep = mocker.patch("app.services.fetcher.time.sleep")
+    error = HTTPError(url=None, code=429, msg="Too Many Requests", hdrs=None, fp=None)
+    download.side_effect = [error, error, _sample_df()]
+
+    df = fetch_prices("AAPL", date(2024, 1, 1), date(2024, 1, 2), settings=settings)
+
+    assert download.call_count == 3
+    assert sleep.call_args_list == [mocker.call(1.0), mocker.call(2.0)]
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
+
+
+def test_fetch_prices_refetch_start(mocker):
+    settings = Settings(YF_REFETCH_DAYS=3)
+    download = mocker.patch("app.services.fetcher.yf.download", return_value=_sample_df())
+
+    fetch_prices(
+        "AAPL",
+        date(2024, 1, 1),
+        date(2024, 1, 10),
+        settings=settings,
+        last_date=date(2024, 1, 5),
+    )
+
+    assert download.call_args.kwargs["start"] == date(2024, 1, 2)


### PR DESCRIPTION
## Summary
- implement fetch_prices service with N-day refetch and exponential backoff
- add unit tests for backoff and refetch start logic
- update task list for T054

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12530f0dc8328bf224ae13b05d02a