### PR TITLE
feat: T060 common error handler

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -350,11 +350,11 @@ tasks:
   description: エラーJSONの統一
   acceptance_criteria:
     - "レスポンス: {error:{code:string, message:string}} 形状"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-14"
+  end: "2025-09-14"
+  notes: "Implemented unified error handlers and tests"
 
 - id: T061
   title: /healthz 実装

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -1,0 +1,41 @@
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+
+def raise_http_error(status_code: int, message: str) -> None:
+    """Raise an HTTPException with a unified error structure.
+
+    Parameters
+    ----------
+    status_code: int
+        HTTP status code to raise.
+    message: str
+        Human readable error message.
+    """
+    raise HTTPException(status_code=status_code, detail=message)
+
+
+def _http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
+    message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    payload = {"error": {"code": str(exc.status_code), "message": message}}
+    return JSONResponse(payload, status_code=exc.status_code)
+
+
+def _validation_exception_handler(
+    _: Request, exc: RequestValidationError
+) -> JSONResponse:
+    message = exc.errors()[0]["msg"] if exc.errors() else "Validation error"
+    payload = {"error": {"code": "422", "message": message}}
+    return JSONResponse(payload, status_code=422)
+
+
+def init_error_handlers(app: FastAPI) -> None:
+    """Register exception handlers on the given FastAPI app."""
+    app.add_exception_handler(HTTPException, _http_exception_handler)
+    app.add_exception_handler(RequestValidationError, _validation_exception_handler)
+
+    async def _not_found(request: Request, exc: HTTPException):
+        return _http_exception_handler(request, exc)
+
+    app.add_exception_handler(404, _not_found)

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,8 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from app.api.errors import init_error_handlers
+
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
@@ -21,6 +23,7 @@ async def lifespan(_: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+init_error_handlers(app)
 
 
 @app.get("/healthz")

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI, status
+from fastapi.testclient import TestClient
+
+from app.api.errors import init_error_handlers, raise_http_error
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    init_error_handlers(app)
+
+    @app.get("/needs-int/{value}")
+    async def needs_int(value: int) -> dict[str, int]:
+        return {"value": value}
+
+    @app.get("/limited")
+    async def limited() -> None:
+        raise_http_error(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, "too large")
+
+    return app
+
+
+def test_404_error_shape() -> None:
+    client = TestClient(create_app())
+    resp = client.get("/missing")
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+    assert resp.json() == {"error": {"code": "404", "message": "Not Found"}}
+
+
+def test_422_error_shape() -> None:
+    client = TestClient(create_app())
+    resp = client.get("/needs-int/not-an-int")
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    body = resp.json()
+    assert body["error"]["code"] == "422"
+    assert "valid integer" in body["error"]["message"]
+
+
+def test_413_error_shape() -> None:
+    client = TestClient(create_app())
+    resp = client.get("/limited")
+    assert resp.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert resp.json() == {"error": {"code": "413", "message": "too large"}}


### PR DESCRIPTION
## Summary
- implement unified error handlers returning `{error:{code,message}}`
- add unit tests for 404/422/413 cases

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b132796df88328aa11480a9501bf1c