### PR TITLE
fix/T062 implement symbols endpoint stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: install test format
 
 install:
-pip install -r requirements.txt
+	pip install -r requirements.txt
+	pip install --upgrade yfinance
 
 test:
-pytest -q
+	PYTHONPATH=. pytest -q
 
 format:
-black .
+	black .

--- a/Master Task List.md
+++ b/Master Task List.md
@@ -336,7 +336,7 @@ tasks:
   owner: "assistant"
   start: "2025-09-13"
   end: "2025-09-13"
-  notes: "Added advisory lock helper and test; updated yfinance to latest"
+  notes: "Added advisory lock helper and test; ensured yfinance is upgraded to latest during install"
 
 # ========= 6. API ルータ =========
 - id: T060
@@ -386,11 +386,11 @@ tasks:
   description: 一覧エンドポイントの枠
   acceptance_criteria:
     - "クエリパラメータ active がbool扱いされる"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-16"
+  end: "2025-09-16"
+  notes: "Symbols endpoint stub implemented"
 
 - id: T063
   title: /v1/prices（解決区間→不足検知→取得→UPSERT→SELECT の枠）

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/v1")
+from .symbols import router as symbols_router
 
-# Placeholder for future v1 endpoints (symbols, prices, metrics)
+router = APIRouter(prefix="/v1")
+router.include_router(symbols_router)
+
+# Placeholder for future v1 endpoints (prices, metrics)

--- a/app/api/v1/symbols.py
+++ b/app/api/v1/symbols.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_session
+from app.schemas.symbols import SymbolOut
+
+router = APIRouter()
+
+
+@router.get("/symbols", response_model=list[SymbolOut])
+async def list_symbols(
+    active: bool | None = Query(default=None),
+    session: AsyncSession = Depends(get_session),
+) -> list[SymbolOut]:
+    """Return symbols, optionally filtered by active flag.
+
+    This is a stub implementation that delegates to raw SQL execution
+    on the provided session. The repository layer will replace this
+    logic in later tasks.
+    """
+    stmt = text("SELECT symbol FROM symbols")
+    params: dict[str, Any] = {}
+    if active is not None:
+        stmt = text("SELECT symbol FROM symbols WHERE is_active = :active")
+        params["active"] = active
+
+    result = await session.execute(stmt, params)
+    rows = result.fetchall()
+    return [SymbolOut(symbol=row.symbol) for row in rows]

--- a/tests/unit/test_symbols_api.py
+++ b/tests/unit/test_symbols_api.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.api.deps import get_session
+
+
+def test_symbols_active_param_is_boolean():
+    session = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = [SimpleNamespace(symbol="AAA")]
+    session.execute.return_value = result
+
+    async def override_get_session():
+        return session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    client = TestClient(app)
+    response = client.get("/v1/symbols?active=true")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["symbol"] == "AAA"
+
+    session.execute.assert_called_once()
+    args, _ = session.execute.call_args
+    assert args[1]["active"] is True
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- implement /v1/symbols stub endpoint with optional `active` filter
- ensure install upgrades yfinance and test target sets PYTHONPATH
- add unit test for symbol endpoint

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b148daf0cc8328b9eff89f36b5dd07