### PR TITLE
feat: implement metrics endpoint (T064)

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -421,11 +421,11 @@ tasks:
   description: メトリクスAPI
   acceptance_criteria:
     - "出力が MetricsOut の配列であること"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-18"
+  end: "2025-09-18"
+  notes: "Implemented metrics endpoint and unit test"
 
 # ========= 7. DB クエリ層 =========
 - id: T070

--- a/app/api/v1/metrics.py
+++ b/app/api/v1/metrics.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, List
+
+import pandas as pd
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_session
+from app.api.errors import raise_http_error
+from app.schemas.metrics import MetricsOut
+from app.services import normalize
+from app.services.metrics import compute_metrics
+
+
+router = APIRouter()
+
+
+def _as_mapping(row: object) -> dict:  # pragma: no cover - helper
+    if hasattr(row, "_mapping"):
+        return dict(row._mapping)
+    if isinstance(row, dict):
+        return row
+    return {k: getattr(row, k) for k in row.__dict__}
+
+
+@router.get("/metrics", response_model=list[MetricsOut])
+async def get_metrics(
+    symbols: str = Query(..., description="Comma separated symbols"),
+    from_: date = Query(..., alias="from"),
+    to: date = Query(..., alias="to"),
+    session: AsyncSession = Depends(get_session),
+) -> List[MetricsOut]:
+    """Compute metrics for the given symbols and date range.
+
+    Database access is intentionally represented via a simple SQL query whose
+    result is transformed into DataFrames before passing to
+    :func:`compute_metrics`. The query is expected to be mocked in tests.
+    """
+
+    if to < from_:
+        raise_http_error(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "'from' must be on or before 'to'",
+        )
+
+    symbol_list = [normalize.normalize_symbol(s) for s in symbols.split(",") if s]
+    result = await session.execute(
+        "SELECT symbol, date, close FROM prices WHERE symbol = ANY(:symbols) "
+        "AND date BETWEEN :from AND :to",
+        {"symbols": symbol_list, "from": from_, "to": to},
+    )
+    rows = [_as_mapping(r) for r in result.fetchall()]
+
+    frames: Dict[str, pd.DataFrame] = {}
+    for sym in symbol_list:
+        sym_rows = [r for r in rows if r["symbol"] == sym]
+        if sym_rows:
+            frames[sym] = pd.DataFrame(sym_rows)
+        else:
+            frames[sym] = pd.DataFrame()
+
+    metrics = compute_metrics(frames)
+    return [MetricsOut(**m) for m in metrics]
+
+
+__all__ = ["router", "get_metrics"]

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -2,9 +2,9 @@ from fastapi import APIRouter
 
 from .symbols import router as symbols_router
 from .prices import router as prices_router
+from .metrics import router as metrics_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(symbols_router)
 router.include_router(prices_router)
-
-# Placeholder for future v1 endpoints (metrics)
+router.include_router(metrics_router)

--- a/tests/unit/test_metrics_api.py
+++ b/tests/unit/test_metrics_api.py
@@ -1,0 +1,60 @@
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_session
+from app.main import app
+
+
+def _setup_session(rows: list) -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    session.execute.return_value = result
+    return session
+
+
+def test_metrics_endpoint(monkeypatch, mocker):
+    rows = [
+        {"symbol": "A", "date": date(2023, 1, 1), "close": 1.0},
+        {"symbol": "A", "date": date(2023, 1, 2), "close": 1.1},
+    ]
+
+    session = _setup_session(rows)
+
+    async def override_get_session():
+        return session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    compute_mock = mocker.patch(
+        "app.api.v1.metrics.compute_metrics",
+        return_value=[
+            {
+                "symbol": "A",
+                "cagr": 1.0,
+                "stdev": 2.0,
+                "max_drawdown": 0.5,
+                "n_days": 1,
+            }
+        ],
+    )
+
+    client = TestClient(app)
+    resp = client.get("/v1/metrics?symbols=A&from=2023-01-01&to=2023-01-02")
+    assert resp.status_code == 200
+    assert resp.json() == [
+        {
+            "symbol": "A",
+            "cagr": 1.0,
+            "stdev": 2.0,
+            "max_drawdown": 0.5,
+            "n_days": 1,
+        }
+    ]
+
+    args, _ = compute_mock.call_args
+    assert "A" in args[0]
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add /v1/metrics endpoint using compute_metrics
- cover metrics endpoint with unit test
- record task completion in Master Task List

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b15a8933c88328b0e1dcfabc84470c