### PR TITLE
feat: T110 Dockerfile and entrypoint

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -529,11 +529,11 @@ tasks:
   description: デプロイ用のコードファイル
   acceptance_criteria:
     - "ファイルが存在し、CMD/ENTRYPOINTの文字列が期待どおり（文字列検証）"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-24"
+  end: "2025-09-24"
+  notes: "Added Dockerfile and entrypoint script"
 
 - id: T111
   title: docker-compose.yml（開発用）

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+RUN chmod +x docker/entrypoint.sh
+
+ENTRYPOINT ["./docker/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+alembic upgrade head
+
+gunicorn app.main:app --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_dockerfile_has_entrypoint():
+    dockerfile = Path("docker/Dockerfile")
+    assert dockerfile.exists()
+    content = dockerfile.read_text()
+    assert 'ENTRYPOINT ["./docker/entrypoint.sh"]' in content
+
+
+def test_entrypoint_contains_commands():
+    entrypoint = Path("docker/entrypoint.sh")
+    assert entrypoint.exists()
+    text = entrypoint.read_text()
+    assert "alembic upgrade head" in text
+    assert "gunicorn" in text


### PR DESCRIPTION
## Summary
- add Dockerfile for Python 3.11 image and entrypoint
- provide entrypoint script running Alembic migrations and Gunicorn
- record task progress in Master Task List

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17bc62be083288490f6ad1e4a2a71