### PR TITLE
feat: T111 add docker-compose

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -544,11 +544,11 @@ tasks:
   description: ローカル実行のための構成ファイル（コードのみ）
   acceptance_criteria:
     - "services.api.build.context が ./ に設定されていること（YAML検証）"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-25"
+  end: "2025-09-25"
+  notes: "docker-compose for dev added"
 
 - id: T112
   title: render.yaml（Render用設定ファイル）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.9'
+services:
+  api:
+    build:
+      context: ./
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/postgres
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+  adminer:
+    image: adminer:4
+    restart: always
+    ports:
+      - "8080:8080"
+    depends_on:
+      - postgres

--- a/requirements.in
+++ b/requirements.in
@@ -12,3 +12,6 @@ httpx
 pytest
 pytest-asyncio
 pytest-mock
+pyyaml
+aiosqlite
+trio

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ httpx==0.27.0
 pytest==8.2.0
 pytest-asyncio==0.23.6
 pytest-mock==3.12.0
+pyyaml==6.0.1
+aiosqlite==0.21.0
+trio==0.30.0

--- a/tests/unit/test_docker_compose.py
+++ b/tests/unit/test_docker_compose.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+import yaml
+
+
+def test_docker_compose_build_context():
+    compose = Path("docker-compose.yml")
+    assert compose.exists()
+    data = yaml.safe_load(compose.read_text())
+    assert data["services"]["api"]["build"]["context"] == "./"


### PR DESCRIPTION
## Summary
- add docker-compose setup with api, postgres, and adminer services
- unit test verifies build context path
- include YAML and async test dependencies

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17d5907588328b4c45d13d62e80b7