### PR TITLE
fix: exec gunicorn in entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,4 +3,7 @@ set -e
 
 alembic upgrade head
 
-gunicorn app.main:app --bind 0.0.0.0:8000 -k uvicorn.workers.UvicornWorker
+# Replace the shell with gunicorn so it becomes PID 1 and receives signals directly.
+exec gunicorn app.main:app \
+  -k uvicorn.workers.UvicornWorker \
+  -b 0.0.0.0:${PORT:-8000}

--- a/tests/unit/test_entrypoint_exec.py
+++ b/tests/unit/test_entrypoint_exec.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_entrypoint_uses_exec_for_gunicorn():
+    p = Path("docker/entrypoint.sh")
+    assert p.exists()
+    text = p.read_text(encoding="utf-8")
+    assert "alembic upgrade head" in text
+    assert "exec gunicorn" in text


### PR DESCRIPTION
## Summary
- replace shell with `exec` when launching gunicorn so it becomes PID 1 and receives signals directly
- add unit test verifying entrypoint uses `exec`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68b17f203250832880e1ddf3ce3df789