### PR TITLE
T112: add Render deployment config

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -559,11 +559,11 @@ tasks:
   description: Render設定（コードのみ）
   acceptance_criteria:
     - "healthCheckPath: /healthz が含まれる"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-26"
+  end: "2025-09-26"
+  notes: "Render config with health check"
 
 # ========= 12. API バリデーション強化 =========
 - id: T120

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: api
+    env: docker
+    startCommand: ./docker/entrypoint.sh
+    healthCheckPath: /healthz

--- a/tests/unit/test_render_yaml.py
+++ b/tests/unit/test_render_yaml.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import yaml
+
+
+def test_render_yaml_has_healthcheck_and_start_command():
+    render = Path("render.yaml")
+    assert render.exists()
+    data = yaml.safe_load(render.read_text())
+    service = data["services"][0]
+    assert service["healthCheckPath"] == "/healthz"
+    assert service["startCommand"] == "./docker/entrypoint.sh"
+    assert service["env"] == "docker"
+    assert service["type"] == "web"
+


### PR DESCRIPTION
## Summary
- add `render.yaml` with health check path and start command
- test render config presence
- update task list for T112

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b183affdfc8328b7b0e5ca79ee9e0d