### PR TITLE
fix: T121 metrics common trading day intersection

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -594,11 +594,11 @@ tasks:
   description: 計算の厳密化
   acceptance_criteria:
     - "交差前後で N が期待どおりに変化"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-09-28"
+  end: "2025-09-28"
+  notes: "Added common trading day intersection and tests"
 
 # ========= 13. 取得フローの統合（モックで） =========
 - id: T130

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -76,10 +76,22 @@ def compute_metrics(price_frames: Dict[str, pd.DataFrame]) -> List[dict]:
     # Determine common trading days across all symbols
     common_index = _common_trading_index(series_map)
 
+    if len(common_index) <= 1:
+        return [
+            {
+                "symbol": symbol,
+                "cagr": 0.0,
+                "stdev": 0.0,
+                "max_drawdown": 0.0,
+                "n_days": 0,
+            }
+            for symbol in price_frames.keys()
+        ]
+
     results: List[dict] = []
     for symbol in price_frames.keys():
         series = series_map.get(symbol)
-        if series is None or len(common_index) == 0:
+        if series is None:
             results.append(
                 {
                     "symbol": symbol,
@@ -91,7 +103,7 @@ def compute_metrics(price_frames: Dict[str, pd.DataFrame]) -> List[dict]:
             )
             continue
 
-        aligned = series.reindex(common_index).dropna()
+        aligned = series.reindex(common_index)
         log_ret = np.log(aligned / aligned.shift(1)).dropna()
         n = int(log_ret.shape[0])
 

--- a/tests/unit/test_metrics_common_days.py
+++ b/tests/unit/test_metrics_common_days.py
@@ -1,3 +1,4 @@
+import math
 import pandas as pd
 
 from app.services.metrics import compute_metrics
@@ -26,9 +27,9 @@ def test_common_trading_days_intersection_applied():
     assert by_symbol["BBB"]["n_days"] == 2
 
     # Ensure metrics are numeric and not NaN
-    assert isinstance(by_symbol["AAA"]["cagr"], float)
-    assert isinstance(by_symbol["AAA"]["stdev"], float)
-    assert isinstance(by_symbol["AAA"]["max_drawdown"], float)
+    for key in ("cagr", "stdev", "max_drawdown"):
+        assert isinstance(by_symbol["AAA"][key], float)
+        assert not math.isnan(by_symbol["AAA"][key])
 
 
 def test_empty_or_single_day_results_are_safe():


### PR DESCRIPTION
## Summary
- ensure metrics computation aligns symbols on common trading days and handles insufficient data
- strengthen metrics common-day test to guard against NaN values
- update task list for T121 completion

## Testing
- `PYTHONPATH=. pytest tests/unit/test_metrics_common_days.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite'; ModuleNotFoundError: No module named 'trio')*

------
https://chatgpt.com/codex/tasks/task_e_68b188229bd88328bf63ddc8e89372b1