### PR TITLE
fix(compose): wait for Postgres via healthcheck and service_healthy depends_on

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,25 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/postgres
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+        # 任意: DB再起動時にAPIも再起動させたい場合は次行を有効化
+        # restart: true
   postgres:
     image: postgres:16
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
     ports:
       - "5432:5432"
+    healthcheck:
+      # Postgres が接続受付可能かをチェック（公式手順）
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres} -h localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
   adminer:
     image: adminer:4
     restart: always

--- a/tests/unit/test_compose_wait_for_db.py
+++ b/tests/unit/test_compose_wait_for_db.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import yaml
+
+
+def test_compose_has_healthcheck_and_condition():
+    compose = Path("docker-compose.yml")
+    text = compose.read_text(encoding="utf-8")
+    assert "services:" in text
+    data = yaml.safe_load(text)
+    # Postgres health check
+    postgres = data["services"]["postgres"]
+    assert "healthcheck" in postgres
+    assert "pg_isready" in postgres["healthcheck"]["test"][1]
+    # API depends on postgres service being healthy
+    api_depends = data["services"]["api"]["depends_on"]["postgres"]
+    assert api_depends["condition"] == "service_healthy"


### PR DESCRIPTION
## Summary
- ensure API waits for healthy Postgres before starting using `depends_on` with `service_healthy`
- add `pg_isready`-based healthcheck for Postgres service
- test docker-compose includes the healthcheck and depends_on condition

## Testing
- `pytest tests/unit/test_compose_wait_for_db.py tests/unit/test_docker_compose.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68b189d82c2c83288669a040cd9a862f