### PR TITLE
fix: retry on requests timeouts

### DIFF
--- a/app/services/fetcher.py
+++ b/app/services/fetcher.py
@@ -6,6 +6,7 @@ from typing import Optional
 from urllib.error import HTTPError
 
 import pandas as pd
+import requests
 import yfinance as yf
 
 from app.core.config import Settings
@@ -77,8 +78,19 @@ def fetch_prices(
         except (
             HTTPError,
             TimeoutError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ReadTimeout,
+            requests.exceptions.ConnectTimeout,
         ) as exc:  # pragma: no cover - branch executed in tests
-            retryable = isinstance(exc, TimeoutError) or getattr(exc, "code", None) in {
+            retryable = isinstance(
+                exc,
+                (
+                    TimeoutError,
+                    requests.exceptions.Timeout,
+                    requests.exceptions.ReadTimeout,
+                    requests.exceptions.ConnectTimeout,
+                ),
+            ) or getattr(exc, "code", None) in {
                 429,
                 999,
             }

--- a/tests/unit/test_fetcher_retry_timeout.py
+++ b/tests/unit/test_fetcher_retry_timeout.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pandas as pd
 import pytest
+import requests
 
 from app.core.config import Settings
 from app.services.fetcher import fetch_prices
@@ -18,6 +19,19 @@ def _sample_df():
         },
         index=pd.to_datetime(["2024-01-01"]),
     )
+
+
+def test_requests_timeout_is_retried_then_succeeds(mocker):
+    settings = Settings(FETCH_MAX_RETRIES=3, FETCH_BACKOFF_MAX_SECONDS=2)
+    download = mocker.patch("app.services.fetcher.yf.download")
+    sleep = mocker.patch("app.services.fetcher.time.sleep")
+    download.side_effect = [requests.exceptions.Timeout("boom"), _sample_df()]
+
+    df = fetch_prices("AAPL", date(2024, 1, 1), date(2024, 1, 2), settings=settings)
+
+    assert download.call_count == 2
+    assert sleep.call_args_list == [mocker.call(1.0)]
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]
 
 
 def test_retry_succeeds_within_limit(mocker):


### PR DESCRIPTION
## Summary
- handle requests timeouts in fetcher
- add test ensuring requests timeout retried

## Testing
- `PYTHONPATH=. pytest tests/unit/test_fetcher_retry_timeout.py tests/unit/test_fetcher.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1955572908328987115865ccb860e