### PR TITLE
feat: add metrics endpoint e2e test (T151)

### DIFF
--- a/Master Task List.md
+++ b/Master Task List.md
@@ -661,11 +661,11 @@ tasks:
   description: メトリクスの契約テスト
   acceptance_criteria:
     - "cagr/stdev/max_drawdown/n_days が存在し型が数値"
-  status: ""
-  owner: ""
-  start: ""
-  end: ""
-  notes: ""
+  status: "done"
+  owner: "assistant"
+  start: "2025-10-02"
+  end: "2025-10-02"
+  notes: "metrics endpoint E2E test"
 
 # ========= 16. CI（コードのみ） =========
 - id: T160

--- a/tests/e2e/test_metrics_endpoint.py
+++ b/tests/e2e/test_metrics_endpoint.py
@@ -1,0 +1,51 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_session
+from app.main import app
+
+
+class FakeResult:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+
+class FakeSession:
+    async def execute(self, sql, params=None):
+        rows = [
+            {"symbol": "META", "date": date(2024, 1, 1), "close": 100.0},
+            {"symbol": "META", "date": date(2024, 1, 2), "close": 110.0},
+            {"symbol": "META", "date": date(2024, 1, 3), "close": 120.0},
+        ]
+        return FakeResult(rows)
+
+
+async def override_get_session():
+    return FakeSession()
+
+
+def test_metrics_endpoint_returns_metrics(monkeypatch):
+    app.dependency_overrides[get_session] = override_get_session
+    monkeypatch.setattr("app.api.v1.metrics.normalize.normalize_symbol", lambda s: s)
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/v1/metrics",
+            params={"symbols": "META", "from": "2024-01-01", "to": "2024-01-03"},
+        )
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    item = data[0]
+    assert item["symbol"] == "META"
+    assert isinstance(item["cagr"], (int, float))
+    assert isinstance(item["stdev"], (int, float))
+    assert isinstance(item["max_drawdown"], (int, float))
+    assert isinstance(item["n_days"], int)


### PR DESCRIPTION
## Summary
- add contract test for /v1/metrics endpoint
- record completion of T151 in Master Task List

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1966f555c8328b127be8b56798a25