### PR TITLE
PR#3: enforce UTC timestamps and price checks

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Database models for core tables."""
+
+from __future__ import annotations
 
 import sqlalchemy as sa
 from sqlalchemy import Index
@@ -49,13 +49,18 @@ class Price(Base):
             ["symbol"], ["symbols.symbol"], onupdate="CASCADE", ondelete="RESTRICT"
         ),
         sa.CheckConstraint(
-            "high >= low AND high >= open AND high >= close AND low <= open AND low <= close",
-            name="ck_prices_high_low_range",
+            "low <= LEAST(open, close)",
+            name="ck_prices_low_le_open_close",
+        ),
+        sa.CheckConstraint(
+            "GREATEST(open, close) <= high",
+            name="ck_prices_open_close_le_high",
         ),
         sa.CheckConstraint(
             "open > 0 AND high > 0 AND low > 0 AND close > 0",
-            name="ck_prices_positive",
+            name="ck_prices_positive_ohlc",
         ),
+        sa.CheckConstraint("volume >= 0", name="ck_prices_volume_nonneg"),
     )
 
     symbol = sa.Column(sa.String, nullable=False)

--- a/app/migrations/versions/003_add_price_checks.py
+++ b/app/migrations/versions/003_add_price_checks.py
@@ -1,0 +1,44 @@
+"""add check constraints for prices
+
+Revision ID: 003_add_price_checks
+Revises: 002_fn_prices_resolved
+Create Date: 2025-08-29
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "003_add_price_checks"
+down_revision = "002_fn_prices_resolved"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "ck_prices_low_le_open_close",
+        "prices",
+        "low <= LEAST(open, close)",
+    )
+    op.create_check_constraint(
+        "ck_prices_open_close_le_high",
+        "prices",
+        "GREATEST(open, close) <= high",
+    )
+    op.create_check_constraint(
+        "ck_prices_positive_ohlc",
+        "prices",
+        "open > 0 AND high > 0 AND low > 0 AND close > 0",
+    )
+    op.create_check_constraint(
+        "ck_prices_volume_nonneg",
+        "prices",
+        "volume >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_prices_volume_nonneg", "prices", type_="check")
+    op.drop_constraint("ck_prices_positive_ohlc", "prices", type_="check")
+    op.drop_constraint("ck_prices_open_close_le_high", "prices", type_="check")
+    op.drop_constraint("ck_prices_low_le_open_close", "prices", type_="check")

--- a/fix-task.md
+++ b/fix-task.md
@@ -251,13 +251,13 @@ PR#3: UTC/TZ 保証 & DB Check 制約
 
 ToDo（コミット粒度）
 
-1. feat(schema): enforce tz-aware UTC for last_updated
+1. feat(schema): enforce tz-aware UTC for last_updated ✅
 
 
-2. feat(db): add CHECK constraints for prices (ohlc/volume)
+2. feat(db): add CHECK constraints for prices (ohlc/volume) ✅
 
 
-3. migration(db): create checks for existing table
+3. migration(db): create checks for existing table ✅
 
 
 

--- a/tests/unit/test_migration_add_price_checks.py
+++ b/tests/unit/test_migration_add_price_checks.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+MIGRATION = Path("app/migrations/versions/003_add_price_checks.py")
+
+
+def test_migration_adds_price_checks():
+    content = MIGRATION.read_text()
+    assert "ck_prices_low_le_open_close" in content
+    assert "ck_prices_open_close_le_high" in content
+    assert "ck_prices_positive_ohlc" in content
+    assert "ck_prices_volume_nonneg" in content

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -16,11 +16,10 @@ def test_prices_table_ddl_contains_constraints():
     assert "PRIMARY KEY (symbol, date)" in ddl
     assert "FOREIGN KEY" in ddl and "REFERENCES symbols (symbol)" in ddl
     assert "ON UPDATE CASCADE" in ddl and "ON DELETE RESTRICT" in ddl
-    assert (
-        "CHECK (high >= low AND high >= open AND high >= close AND low <= open AND low <= close)"
-        in ddl
-    )
+    assert "CHECK (low <= LEAST(open, close))" in ddl
+    assert "CHECK (GREATEST(open, close) <= high)" in ddl
     assert "CHECK (open > 0 AND high > 0 AND low > 0 AND close > 0)" in ddl
+    assert "CHECK (volume >= 0)" in ddl
     assert isinstance(models.Price.__table__.c.volume.type, sa.BigInteger)
     assert models.Price.__table__.c.last_updated.type.timezone is True
 

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -13,7 +13,7 @@ def test_date_range_invalid_order_raises():
 
 
 def test_price_row_out_enforces_types():
-    aware = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    aware = datetime(2024, 1, 1, tzinfo=timezone(timedelta(hours=9)))
     row = PriceRowOut(
         symbol="AAA",
         date=date(2024, 1, 1),
@@ -26,7 +26,7 @@ def test_price_row_out_enforces_types():
         last_updated=aware,
     )
     assert isinstance(row.date, date)
-    assert row.last_updated.tzinfo is not None
+    assert row.last_updated.tzinfo == timezone.utc
 
     with pytest.raises(ValidationError):
         PriceRowOut(


### PR DESCRIPTION
## Summary
- enforce UTC conversion for `last_updated` in PriceRowOut
- add database check constraints for price fields and migrate existing table

## Testing
- `ruff check app/schemas/prices.py app/db/models.py tests/unit/test_schemas.py tests/unit/test_models.py tests/unit/test_migration_add_price_checks.py app/migrations/versions/003_add_price_checks.py`
- `black --check app/schemas/prices.py app/db/models.py tests/unit/test_schemas.py tests/unit/test_models.py tests/unit/test_migration_add_price_checks.py app/migrations/versions/003_add_price_checks.py`
- `mypy app` *(fails: Need type annotation for __all__, missing stubs, incompatible types, etc.)*
- `PYTHONPATH=. pytest tests/unit/test_schemas.py tests/unit/test_models.py tests/unit/test_migration_add_price_checks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7a3de4083288687f77e0fe7d44d