### PR TITLE
fix(prices): ensure coverage and adjust get_prices_resolved usage

### DIFF
--- a/app/api/v1/prices.py
+++ b/app/api/v1/prices.py
@@ -63,13 +63,17 @@ async def get_prices(
         refetch_days=settings.YF_REFETCH_DAYS,
     )
 
-    # 2) 透過解決済み結果を取得
-    rows = await queries.get_prices_resolved(
-        session=session,
-        symbols=symbols_list,
-        date_from=date_from,
-        date_to=date_to,
-    )
+    # 2) 透過解決済み結果を取得（単一シンボル関数に合わせて結合）
+    rows: List[dict] = []
+    for s in symbols_list:
+        part = await queries.get_prices_resolved(session, s, date_from, date_to)
+        if part:
+            for r in part:
+                if not isinstance(r, dict):
+                    r = dict(r)
+                rows.append(r)
+
+    rows.sort(key=lambda r: (r.get("date"), r.get("symbol")))
 
     if len(rows) > settings.API_MAX_ROWS:
         raise HTTPException(status_code=413, detail="response too large")


### PR DESCRIPTION
## Summary
- add `ensure_coverage` helper that locks and upserts fresh price data
- adapt `/v1/prices` to loop single-symbol `get_prices_resolved` and sort results

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1baca39b88328a72d35ce38894197