### PR TITLE
fix(schema): keep PriceRowOut.date as date-only per contract

### DIFF
--- a/app/schemas/prices.py
+++ b/app/schemas/prices.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Optional
 
 try:
@@ -11,7 +11,8 @@ except Exception:  # v1 fallback
 
 class PriceRowOut(BaseModel):
     symbol: str
-    date: datetime | str  # ISO 日付文字列も許容（FastAPI の JSON エンコーダ対応）
+    # Contract: date-only (YYYY-MM-DD). PydanticはISO文字列を自動でdateに変換します。
+    date: date
     open: float
     high: float
     low: float
@@ -24,6 +25,7 @@ class PriceRowOut(BaseModel):
     @field_validator("last_updated")
     @classmethod
     def _tz_aware_utc(cls, v: datetime) -> datetime:
+        # timezone-aware を必須化し、常に UTC に正規化
         if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
             raise ValueError("last_updated must be timezone-aware")
         return v.astimezone(timezone.utc)

--- a/tests/unit/test_price_row_out_date_serialization.py
+++ b/tests/unit/test_price_row_out_date_serialization.py
@@ -1,0 +1,44 @@
+import json
+from datetime import date, datetime, timezone
+
+from app.schemas.prices import PriceRowOut
+
+
+def _dump_model(m):
+    # pydantic v2 / v1 両対応
+    if hasattr(m, "model_dump"):
+        return m.model_dump()
+    return m.dict()
+
+
+def _dump_json(m):
+    # pydantic v2 / v1 両対応
+    if hasattr(m, "model_dump_json"):
+        return m.model_dump_json()
+    return json.dumps(m.dict(), default=str)
+
+
+def test_date_is_date_only_and_last_updated_tzaware():
+    m = PriceRowOut(
+        symbol="AAPL",
+        date="2024-01-02",  # 文字列でもdateに変換される
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.5,
+        volume=1,
+        source="yfinance",
+        last_updated=datetime(2024, 1, 2, 12, 0, tzinfo=timezone.utc),
+    )
+    # Python モデル上は date 型
+    assert isinstance(m.date, date)
+    # tz-aware であること
+    assert m.last_updated.tzinfo is not None and m.last_updated.utcoffset() is not None
+
+    # dict では date オブジェクト
+    payload = _dump_model(m)
+    assert payload["date"] == date(2024, 1, 2)
+
+    # JSON は "YYYY-MM-DD"（時刻なし）
+    j = _dump_json(m)
+    assert '"date":"2024-01-02"' in j


### PR DESCRIPTION
## Summary
- ensure PriceRowOut.date stays date-only per API contract
- verify serialization of date-only and tz-aware last_updated

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1bcd3eb8c83289cd76d82bde0af25