### PR TITLE
fix: resolve ruff lint errors

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Dependency injection utilities for FastAPI routers."""
+
+from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from functools import lru_cache

--- a/app/api/v1/metrics.py
+++ b/app/api/v1/metrics.py
@@ -13,7 +13,6 @@ from app.schemas.metrics import MetricsOut
 from app.services import normalize
 from app.services.metrics import compute_metrics
 
-
 router = APIRouter()
 
 

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,8 +1,8 @@
 from fastapi import APIRouter
 
-from .symbols import router as symbols_router
-from .prices import router as prices_router
 from .metrics import router as metrics_router
+from .prices import router as prices_router
+from .symbols import router as symbols_router
 
 router = APIRouter(prefix="/v1")
 router.include_router(symbols_router)

--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -8,7 +8,6 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import Settings
 
-
 MiddlewareConfig = Tuple[Type[CORSMiddleware], Dict[str, Any]]
 
 

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """SQLAlchemy declarative base for ORM models."""
+
+from __future__ import annotations
 
 from sqlalchemy.orm import DeclarativeBase
 

--- a/app/management/cli.py
+++ b/app/management/cli.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import typer
 
-from app.services import normalize
 from app.management.commands import add_symbol as add_symbol_cmd
+from app.services import normalize
 
 app = typer.Typer()
 

--- a/app/migrations/versions/001_init.py
+++ b/app/migrations/versions/001_init.py
@@ -1,5 +1,5 @@
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "001_init"

--- a/app/schemas/prices.py
+++ b/app/schemas/prices.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from datetime import date, datetime, timezone
 from typing import Optional
 
@@ -6,7 +7,8 @@ try:
     # Pydantic v2
     from pydantic import BaseModel, Field, field_validator
 except Exception:  # v1 fallback
-    from pydantic import BaseModel, Field, validator as field_validator  # type: ignore
+    from pydantic import BaseModel, Field  # type: ignore
+    from pydantic import validator as field_validator
 
 
 class PriceRowOut(BaseModel):

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -5,7 +5,6 @@ from typing import Dict, List
 import numpy as np
 import pandas as pd
 
-
 TRADING_DAYS_PER_YEAR = 252
 
 

--- a/app/services/resolver.py
+++ b/app/services/resolver.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Iterable, List, Tuple, Any
+from typing import Any, Iterable, List, Tuple
 
 
 def _get(row: Any, key: str):

--- a/tests/unit/test_compose_wait_for_db.py
+++ b/tests/unit/test_compose_wait_for_db.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import yaml
 
 

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -1,6 +1,7 @@
+from fastapi.middleware.cors import CORSMiddleware
+
 from app.core.config import Settings
 from app.core.cors import create_cors_middleware
-from fastapi.middleware.cors import CORSMiddleware
 
 
 def test_cors_middleware_disabled_when_origins_empty():

--- a/tests/unit/test_db_utils.py
+++ b/tests/unit/test_db_utils.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
 
 from app.db.utils import advisory_lock
 

--- a/tests/unit/test_docker_compose.py
+++ b/tests/unit/test_docker_compose.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import yaml
 
 

--- a/tests/unit/test_fetcher.py
+++ b/tests/unit/test_fetcher.py
@@ -2,6 +2,7 @@ from datetime import date
 from urllib.error import HTTPError
 
 import pandas as pd
+
 from app.core.config import Settings
 from app.services.fetcher import fetch_prices
 

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -2,7 +2,6 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-
 client = TestClient(app)
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,5 +1,5 @@
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 
 from app.services.metrics import compute_metrics

--- a/tests/unit/test_metrics_common_days.py
+++ b/tests/unit/test_metrics_common_days.py
@@ -1,4 +1,5 @@
 import math
+
 import pandas as pd
 
 from app.services.metrics import compute_metrics

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,4 +1,3 @@
-import pytest
 
 from app.services.normalize import normalize_symbol
 

--- a/tests/unit/test_render_yaml.py
+++ b/tests/unit/test_render_yaml.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import yaml
 
 

--- a/tests/unit/test_symbols_api.py
+++ b/tests/unit/test_symbols_api.py
@@ -3,8 +3,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 from fastapi.testclient import TestClient
 
-from app.main import app
 from app.api.deps import get_session
+from app.main import app
 
 
 def test_symbols_active_param_is_boolean():


### PR DESCRIPTION
## Summary
- reorder imports and move module docstrings above imports to satisfy ruff
- remove unused imports

## Testing
- `ruff check .`
- `pytest` *(fails: 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c05892ac83289f8200bc084afb37