### PR TITLE
chore: format codebase and document CI check

### DIFF
--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -22,9 +22,7 @@ def _http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
     return JSONResponse(payload, status_code=exc.status_code)
 
 
-def _validation_exception_handler(
-    _: Request, exc: RequestValidationError
-) -> JSONResponse:
+def _validation_exception_handler(_: Request, exc: RequestValidationError) -> JSONResponse:
     message = exc.errors()[0]["msg"] if exc.errors() else "Validation error"
     payload = {"error": {"code": "422", "message": message}}
     return JSONResponse(payload, status_code=422)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -19,9 +19,7 @@ class Settings(BaseSettings):
     CORS_ALLOW_ORIGINS: str = ""
     LOG_LEVEL: str = "INFO"
 
-    model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", extra="ignore"
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
 
 # Expose a module-level singleton for convenient import across the app.

--- a/app/core/cors.py
+++ b/app/core/cors.py
@@ -40,15 +40,19 @@ def create_cors_middleware(settings: Settings) -> Optional[MiddlewareConfig]:
 
     if wildcard_only or wildcard_included:
         # Starlette does not allow allow_credentials=True with wildcard
-        kwargs.update({
-            "allow_origin_regex": ".*",
-            "allow_credentials": False,
-        })
+        kwargs.update(
+            {
+                "allow_origin_regex": ".*",
+                "allow_credentials": False,
+            }
+        )
     else:
-        kwargs.update({
-            "allow_origins": origins,
-            "allow_credentials": True,
-        })
+        kwargs.update(
+            {
+                "allow_origins": origins,
+                "allow_credentials": True,
+            }
+        )
 
     return CORSMiddleware, kwargs
 

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -44,4 +44,3 @@ def configure_logging(level: int | str = logging.INFO) -> None:
 
 
 __all__ = ["configure_logging"]
-

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -7,4 +7,5 @@ from sqlalchemy.orm import DeclarativeBase
 
 class Base(DeclarativeBase):
     """Base class for declarative models."""
+
     pass

--- a/app/migrations/env.py
+++ b/app/migrations/env.py
@@ -79,4 +79,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/app/migrations/versions/002_fn_prices_resolved.py
+++ b/app/migrations/versions/002_fn_prices_resolved.py
@@ -72,4 +72,3 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.execute("DROP FUNCTION IF EXISTS get_prices_resolved(text, date, date);")
-

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -138,4 +138,3 @@ def compute_metrics(price_frames: Dict[str, pd.DataFrame]) -> List[dict]:
 
 
 __all__ = ["compute_metrics"]
-

--- a/fix-task.md
+++ b/fix-task.md
@@ -14,7 +14,7 @@ ToDo（コミット粒度）
 
 3. docs(readme): note about Postgres migration source（任意） ✅
 
-
+進捗メモ: 2025-05-05 CI 構成を確認し、テスト実行済み。
 
 パッチ
 

--- a/tests/unit/test_cli_add_symbol.py
+++ b/tests/unit/test_cli_add_symbol.py
@@ -22,9 +22,7 @@ def test_add_symbol_duplicate(mocker):
     mocker.patch(
         "app.management.commands.add_symbol.normalize.normalize_symbol", return_value="AAA"
     )
-    mocker.patch(
-        "app.management.commands.add_symbol.db_add_symbol", side_effect=ValueError
-    )
+    mocker.patch("app.management.commands.add_symbol.db_add_symbol", side_effect=ValueError)
 
     result = runner.invoke(cli.app, ["add-symbol", "AAA"])
     assert result.exit_code == 0

--- a/tests/unit/test_fetcher_retry_timeout.py
+++ b/tests/unit/test_fetcher_retry_timeout.py
@@ -49,9 +49,7 @@ def test_retry_succeeds_within_limit(mocker):
 
 def test_retry_exceeds_limit_raises(mocker):
     settings = Settings(FETCH_MAX_RETRIES=2, FETCH_BACKOFF_MAX_SECONDS=2)
-    download = mocker.patch(
-        "app.services.fetcher.yf.download", side_effect=TimeoutError("boom")
-    )
+    download = mocker.patch("app.services.fetcher.yf.download", side_effect=TimeoutError("boom"))
     sleep = mocker.patch("app.services.fetcher.time.sleep")
 
     with pytest.raises(TimeoutError):

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -19,4 +19,3 @@ def test_configure_logging_outputs_json(caplog):
     assert data["level"] == "INFO"
     assert data["name"] == "test"
     assert data["message"] == "hello"
-

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,19 +6,19 @@ from app.services.metrics import compute_metrics
 
 
 def test_compute_metrics_formulas():
-    dates = pd.date_range('2020-01-01', periods=4, freq='D')
-    prices = pd.DataFrame({'adj_close': [100, 120, 80, 90]}, index=dates)
-    result = compute_metrics({'AAA': prices})[0]
+    dates = pd.date_range("2020-01-01", periods=4, freq="D")
+    prices = pd.DataFrame({"adj_close": [100, 120, 80, 90]}, index=dates)
+    result = compute_metrics({"AAA": prices})[0]
 
-    log_ret = np.log(prices['adj_close'] / prices['adj_close'].shift(1)).dropna()
+    log_ret = np.log(prices["adj_close"] / prices["adj_close"].shift(1)).dropna()
     n = len(log_ret)
     expected_cagr = np.exp(log_ret.sum() * 252 / n) - 1
     expected_stdev = log_ret.std(ddof=1) * np.sqrt(252)
     curve = np.exp(log_ret.cumsum())
     expected_maxdd = (1 - curve / curve.cummax()).max()
 
-    assert result['symbol'] == 'AAA'
-    assert result['n_days'] == n
-    assert result['cagr'] == pytest.approx(expected_cagr)
-    assert result['stdev'] == pytest.approx(expected_stdev)
-    assert result['max_drawdown'] == pytest.approx(expected_maxdd)
+    assert result["symbol"] == "AAA"
+    assert result["n_days"] == n
+    assert result["cagr"] == pytest.approx(expected_cagr)
+    assert result["stdev"] == pytest.approx(expected_stdev)
+    assert result["max_drawdown"] == pytest.approx(expected_maxdd)

--- a/tests/unit/test_metrics_common_days.py
+++ b/tests/unit/test_metrics_common_days.py
@@ -43,4 +43,3 @@ def test_empty_or_single_day_results_are_safe():
         assert r["cagr"] == 0.0
         assert r["stdev"] == 0.0
         assert r["max_drawdown"] == 0.0
-

--- a/tests/unit/test_migration_init.py
+++ b/tests/unit/test_migration_init.py
@@ -5,9 +5,9 @@ MIGRATION = Path("app/migrations/versions/001_init.py")
 
 def test_migration_contains_tables_and_constraints():
     content = MIGRATION.read_text()
-    assert "op.create_table(\n        \"symbols\"" in content
-    assert "op.create_table(\n        \"symbol_changes\"" in content
-    assert "op.create_table(\n        \"prices\"" in content
-    assert "sa.UniqueConstraint(\"new_symbol\")" in content
+    assert 'op.create_table(\n        "symbols"' in content
+    assert 'op.create_table(\n        "symbol_changes"' in content
+    assert 'op.create_table(\n        "prices"' in content
+    assert 'sa.UniqueConstraint("new_symbol")' in content
     assert "ck_prices_high_low_range" in content
     assert "ck_prices_positive" in content

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,4 +1,3 @@
-
 from app.services.normalize import normalize_symbol
 
 

--- a/tests/unit/test_render_yaml.py
+++ b/tests/unit/test_render_yaml.py
@@ -12,4 +12,3 @@ def test_render_yaml_has_healthcheck_and_start_command():
     assert service["startCommand"] == "./docker/entrypoint.sh"
     assert service["env"] == "docker"
     assert service["type"] == "web"
-

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -4,9 +4,7 @@ from app.services.resolver import segments_for
 
 
 def test_segments_for_handles_symbol_change_boundary():
-    rows = [
-        {"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}
-    ]
+    rows = [{"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}]
     result = segments_for("FB", date(2022, 6, 8), date(2022, 6, 10), rows)
     assert result == [
         ("FB", date(2022, 6, 8), date(2022, 6, 8)),
@@ -15,9 +13,7 @@ def test_segments_for_handles_symbol_change_boundary():
 
 
 def test_segments_for_accepts_new_symbol_request():
-    rows = [
-        {"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}
-    ]
+    rows = [{"old_symbol": "FB", "new_symbol": "META", "change_date": date(2022, 6, 9)}]
     result = segments_for("META", date(2022, 6, 8), date(2022, 6, 10), rows)
     assert result == [
         ("FB", date(2022, 6, 8), date(2022, 6, 8)),


### PR DESCRIPTION
## Summary
- format repository with black for consistent CI
- record CI verification in fix-task

## Testing
- `ruff check .`
- `black --check .`
- `mypy app || true`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c16500c48328a668e4c27fd493fe