### PR TITLE
fix(db): use LATERAL for generate_series and alias its column; fix EXTRACT target

### DIFF
--- a/app/db/queries.py
+++ b/app/db/queries.py
@@ -60,14 +60,15 @@ async def _get_coverage(session: AsyncSession, symbol: str, date_from: date, dat
               AND p.date BETWEEN (SELECT dfrom FROM rng) AND (SELECT dto FROM rng)
         ),
         weekdays_between AS (
-            SELECT g.cur_date, g.next_date, gs::date AS d
+            SELECT g.cur_date, g.next_date, (gs.d)::date AS d
             FROM gaps g
-            JOIN generate_series(
+            JOIN LATERAL generate_series(
                     g.cur_date + INTERVAL '1 day',
                     g.next_date - INTERVAL '1 day',
-                    INTERVAL '1 day') AS gs
-              ON g.next_date IS NOT NULL
-            WHERE EXTRACT(ISODOW FROM gs) BETWEEN 1 AND 5
+                    INTERVAL '1 day'
+                 ) AS gs(d) ON TRUE
+            WHERE g.next_date IS NOT NULL
+              AND EXTRACT(ISODOW FROM gs.d) BETWEEN 1 AND 5
         ),
         weekday_gaps AS (
             SELECT cur_date, next_date, MIN(d)::date AS first_weekday_missing


### PR DESCRIPTION
## Summary
- ensure weekday gap detection uses LATERAL generate_series with a column alias
- guard EXTRACT ISODOW calls with the proper gs.d reference

## Testing
- `PYTHONPATH=. pytest`

@codex fix comments

------
https://chatgpt.com/codex/tasks/task_e_68b1c7981a5c8328aead806e169822bd