### PR TITLE
fix: remove future flag from async engine (P0-1)

### DIFF
--- a/app-db-fix.md
+++ b/app-db-fix.md
@@ -75,7 +75,7 @@ P0: ビルド/起動を止める致命傷の除去
 
 ID	タイトル	問題/目的	完了条件(DoD)	検証(テスト/実行例)	変更ファイル（目安）	Owner	Status
 
-P0-1	future=True削除	SQLAlchemy 2.0で不正引数	create_engine_and_sessionmakerがcreate_async_engine(database_url)で初期化できる	python - <<'PY'\nfrom app.db.engine import create_engine_and_sessionmaker;print('ok')\nPY が例外なく走る（モックでOK）	app/db/engine.py（future=True削除） 		☐
+P0-1	future=True削除	SQLAlchemy 2.0で不正引数	create_engine_and_sessionmakerがcreate_async_engine(database_url)で初期化できる	python - <<'PY'\nfrom app.db.engine import create_engine_and_sessionmaker;print('ok')\nPY が例外なく走る（モックでOK）	app/db/engine.py（future=True削除） 	LLM   ✅
 P0-2	AlembicをPG URLに統一	SQLite設定のままだとPG前提のSQLが全滅	alembic.iniのsqlalchemy.urlがpostgresql+psycopg://...に更新。env.pyで環境変数ALEMBIC_SQLALCHEMY_URLが優先される	ALEMBIC_SQLALCHEMY_URL=postgresql+psycopg://... alembic current が動作	alembic.ini, app/migrations/env.py（URL取得を環境変数優先に） 		☐
 P0-3	now()をPG互換に固定	SQLite非互換を排除	server_default=text("now()") などPG向け明示にし、Alembic生成/適用が通る	alembic revision --autogenerate → alembic upgrade head がPGで成功	app/db/models.py（last_updated定義の見直し） 		☐
 

--- a/app/db/engine.py
+++ b/app/db/engine.py
@@ -24,7 +24,7 @@ def create_engine_and_sessionmaker(
         Tuple of async engine and sessionmaker.
     """
 
-    engine = create_async_engine(database_url, future=True)
+    engine = create_async_engine(database_url)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     return engine, session_factory
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -6,3 +6,17 @@ def test_engine_uses_asyncpg_driver():
     settings = Settings()
     engine, _ = create_engine_and_sessionmaker(settings.DATABASE_URL)
     assert engine.url.drivername == "postgresql+asyncpg"
+
+
+def test_create_engine_called_without_future(mocker):
+    mock_create_engine = mocker.patch(
+        "app.db.engine.create_async_engine", return_value=object()
+    )
+    mock_sessionmaker = mocker.patch("app.db.engine.async_sessionmaker")
+
+    create_engine_and_sessionmaker("postgresql+asyncpg://user:pass@localhost/db")
+
+    mock_create_engine.assert_called_once_with(
+        "postgresql+asyncpg://user:pass@localhost/db"
+    )
+    mock_sessionmaker.assert_called_once()


### PR DESCRIPTION
## Summary
- remove deprecated `future=True` flag when creating async engine
- add regression test ensuring no unsupported args are passed
- record P0-1 task completion

## Testing
- `python - <<'PY'
from app.db.engine import create_engine_and_sessionmaker;print('ok')
PY`
- `PYTHONPATH=. pytest tests/unit/test_engine.py -q`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1dcbc1f348328a61cb077b6df59a5