### PR TITLE
fix: enforce postgres migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd="pg_isready -U postgres -d postgres -h 127.0.0.1"
+          --health-interval=5s --health-timeout=5s --health-retries=20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -18,6 +28,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install ruff black mypy
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Alembic upgrade (Postgres)
+        env:
+          ALEMBIC_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/postgres
+        run: alembic upgrade head
+      - name: Alembic downgrade (Postgres)
+        env:
+          ALEMBIC_DATABASE_URL: postgresql+psycopg://postgres:postgres@127.0.0.1:5432/postgres
+        run: alembic downgrade base
       - name: Lint (ruff)
         run: ruff check .
       - name: Format (black --check)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: install test format
+.PHONY: install test format migrate
+
+export ALEMBIC_DATABASE_URL ?= postgresql+psycopg://postgres:postgres@localhost:5432/postgres
 
 install:
 	pip install -r requirements.txt
@@ -9,3 +11,6 @@ test:
 
 format:
 	black .
+
+migrate:
+	alembic upgrade head

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@
 
 ### マイグレーションの実行
 
-Alembic は環境変数 `ALEMBIC_DATABASE_URL` もしくは `DATABASE_URL` を参照して
-Postgres に接続します。Docker 環境ではエントリポイントがこれらの変数から
+Alembic は `ALEMBIC_DATABASE_URL` を優先し、無ければ `DATABASE_URL` を使用します。
+`DATABASE_URL` が `postgresql+asyncpg://` の場合でも、Alembic 側で `postgresql+psycopg://` に
+変換して Postgres に接続します。Docker 環境ではエントリポイントがこれらの変数から
 URL を解決し、`alembic upgrade head` を実行します。
 
 ## テスト方針

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = app/migrations
-sqlalchemy.url = sqlite:///./app.db
+# sqlalchemy.url is injected from env by env.py
+# sqlalchemy.url =
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/app-migrations-fix.md
+++ b/app-migrations-fix.md
@@ -22,7 +22,7 @@ CI と Docker で マイグレーションの up/down を検証できるよう�
 
 1) 依存の追加（Alembic を Postgres 同期ドライバで動かす）
 
-[ ] psycopg を requirements に追加
+[x] psycopg を requirements に追加
 開始条件: 依存の追加作業に入れる
 作業: requirements.txt に 1 行追加（ピン留めポリシーは既存に準拠）
 
@@ -37,7 +37,7 @@ CI と Docker で マイグレーションの up/down を検証できるよう�
 
 2) Alembic が環境変数から URL を読むようにする（かつ asyncpg → psycopg を自動変換）
 
-[ ] app/migrations/env.py に環境変数注入を実装
+[x] app/migrations/env.py に環境変数注入を実装
 開始条件: env.py を編集できる
 作業: 下記パッチを適用（ALEMBIC_DATABASE_URL を優先、無ければ DATABASE_URL。postgresql+asyncpg:// は Alembic 用に postgresql+psycopg:// へ置換）
 
@@ -74,7 +74,7 @@ DATABASE_URL=postgresql+asyncpg://... alembic current でも成功（内部で p
 
 3) SQLite 既定を使わないよう安全化（操作ミス防止）
 
-[ ] alembic.ini の SQLite 既定 URL をコメントアウト or ダミー化
+[x] alembic.ini の SQLite 既定 URL をコメントアウト or ダミー化
 開始条件: alembic.ini を編集できる
 作業: 下記いずれか
 
@@ -92,7 +92,7 @@ DATABASE_URL=postgresql+asyncpg://... alembic current でも成功（内部で p
 
 4) Docker/Compose で Alembic に psycopg URL を渡す
 
-[ ] docker-compose.yml に ALEMBIC_DATABASE_URL を追加
+[x] docker-compose.yml に ALEMBIC_DATABASE_URL を追加
 開始条件: Compose を編集できる
 作業: API サービスの環境変数に追加（アプリは asyncpg、Alembic は psycopg を利用）
 
@@ -115,7 +115,7 @@ ALEMBIC_DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/postg
 
 5) Makefile にワンコマンド・マイグレーションを追加
 
-[ ] make migrate 追加（ローカル検証容易化）
+[x] make migrate 追加（ローカル検証容易化）
 開始条件: Makefile 変更可能
 作業:
 
@@ -139,7 +139,7 @@ ALEMBIC_DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/postg
 
 6) CI で up/down を検証（回帰を防止）
 
-[ ] GitHub Actions に Postgres サービス＋ Alembic up/down を追加
+[x] GitHub Actions に Postgres サービス＋ Alembic up/down を追加
 開始条件: .github/workflows/ci.yml を編集できる
 作業: 下記のように Postgres サービス、クライアント導入、alembic upgrade/downgrade を追加
 
@@ -195,7 +195,7 @@ jobs:
 
 7) ドキュメント整合（実装に合わせる）
 
-[ ] README のマイグレーション節を実装どおりに微修正
+[x] README のマイグレーション節を実装どおりに微修正
 開始条件: README 編集可
 作業: 「Alembic は ALEMBIC_DATABASE_URL 優先、無ければ DATABASE_URL を使用。DATABASE_URL が asyncpg の場合は Alembic 側で psycopg に変換。」の 1 文を追記。
 検証（DoD）: 新しい手順どおりに ALEMBIC_DATABASE_URL=... alembic upgrade head が成功。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./:/app
     environment:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@postgres:5432/postgres
+      ALEMBIC_DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/postgres
     depends_on:
       postgres:
         condition: service_healthy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 sqlalchemy[asyncio]==2.0.29
 asyncpg==0.29.0
+psycopg[binary]==3.2.*
 alembic==1.13.1
 pydantic-settings==2.0.3
 pandas==2.2.2


### PR DESCRIPTION
## Summary
- ensure alembic uses Postgres URLs via environment variables and converts asyncpg driver
- add psycopg dependency and compose/CI hooks for migrations
- document migration workflow and provide Makefile helper

## Testing
- `pip install -r requirements.txt`
- `python -c "import psycopg"`
- `PYTHONPATH=. ALEMBIC_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/postgres alembic current`
- `PYTHONPATH=. DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/postgres alembic current`
- `PYTHONPATH=. alembic current` *(fails: AttributeError: 'NoneType' object has no attribute 'startswith')*
- `docker compose up -d` *(fails: command not found)*
- `ALEMBIC_DATABASE_URL=postgresql+psycopg://postgres:postgres@localhost:5432/postgres PYTHONPATH=. make migrate`
- `ruff check .`
- `black --check .`
- `mypy app` *(fails: Found 8 errors in 4 files)*
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2c7b1d083289a81f2222447be1a