### PR TITLE
fix: improve service fetcher and metrics robustness

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,7 @@
+__all__ = [
+    "fetcher",
+    "metrics",
+    "normalize",
+    "resolver",
+    "upsert",
+]

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -124,6 +124,13 @@ def compute_metrics(price_frames: Dict[str, pd.DataFrame]) -> List[dict]:
         drawdowns = 1.0 - curve / curve.cummax()
         max_dd = float(drawdowns.max()) if n > 0 else 0.0
 
+        if not np.isfinite(cagr):
+            cagr = 0.0
+        if not np.isfinite(stdev):
+            stdev = 0.0
+        if not np.isfinite(max_dd):
+            max_dd = 0.0
+
         results.append(
             {
                 "symbol": symbol,

--- a/tests/unit/test_fetcher_concurrency.py
+++ b/tests/unit/test_fetcher_concurrency.py
@@ -1,0 +1,33 @@
+from datetime import date
+
+import anyio
+import pandas as pd
+import pytest
+
+from app.db import queries
+
+
+@pytest.mark.anyio
+async def test_fetch_prices_df_respects_concurrency_limit(mocker):
+    max_running = 0
+    running = 0
+
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        nonlocal running, max_running
+        running += 1
+        max_running = max(max_running, running)
+        await anyio.sleep(0.01)
+        running -= 1
+        return pd.DataFrame()
+
+    mocker.patch("app.db.queries.run_in_threadpool", side_effect=fake_run_in_threadpool)
+    mocker.patch("app.db.queries.fetch_prices")
+    queries._fetch_semaphore = anyio.Semaphore(2)
+
+    async with anyio.create_task_group() as tg:
+        for _ in range(5):
+            tg.start_soon(
+                queries.fetch_prices_df, "AAPL", date(2024, 1, 1), date(2024, 1, 2)
+            )
+
+    assert max_running <= 2

--- a/tests/unit/test_fetcher_http_error.py
+++ b/tests/unit/test_fetcher_http_error.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import pytest
+import requests
+from datetime import date
+
+from app.core.config import Settings
+from app.services import fetcher
+
+
+def _sample_df():
+    return pd.DataFrame(
+        {
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Adj Close": [1.0],
+            "Volume": [100],
+        },
+        index=pd.to_datetime(["2024-01-01"]),
+    )
+
+
+@pytest.mark.parametrize("status", [429, 999])
+def test_fetcher_retries_on_http_error(status, mocker):
+    settings = Settings(FETCH_MAX_RETRIES=3, FETCH_BACKOFF_MAX_SECONDS=2)
+    err = requests.exceptions.HTTPError(response=mocker.Mock(status_code=status))
+    download = mocker.patch("app.services.fetcher.yf.download", side_effect=[err, _sample_df()])
+    sleep = mocker.patch("app.services.fetcher.time.sleep")
+
+    df = fetcher.fetch_prices("AAPL", date(2024, 1, 1), date(2024, 1, 2), settings=settings)
+
+    assert download.call_count == 2
+    assert sleep.call_count == 1
+    assert list(df.columns) == ["open", "high", "low", "close", "volume"]

--- a/tests/unit/test_fetcher_retry_timeout.py
+++ b/tests/unit/test_fetcher_retry_timeout.py
@@ -15,6 +15,7 @@ def _sample_df():
             "High": [1.0],
             "Low": [1.0],
             "Close": [1.0],
+            "Adj Close": [1.0],
             "Volume": [100],
         },
         index=pd.to_datetime(["2024-01-01"]),
@@ -31,6 +32,7 @@ def test_requests_timeout_is_retried_then_succeeds(mocker):
 
     assert download.call_count == 2
     assert sleep.call_args_list == [mocker.call(1.0)]
+    assert download.call_args.kwargs["timeout"] == settings.FETCH_TIMEOUT_SECONDS
     assert list(df.columns) == ["open", "high", "low", "close", "volume"]
 
 

--- a/tests/unit/test_import_services.py
+++ b/tests/unit/test_import_services.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_import_services_normalize():
+    import app.services
+
+    importlib.reload(app.services)
+    from app.services import normalize
+
+    assert hasattr(normalize, "normalize_symbol")

--- a/tests/unit/test_metrics_finite.py
+++ b/tests/unit/test_metrics_finite.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pandas as pd
+
+from app.services.metrics import compute_metrics
+
+
+def test_metrics_returns_finite_values_even_with_zeros():
+    dates = pd.date_range("2020-01-01", periods=3, freq="D")
+    prices = pd.DataFrame({"adj_close": [100, 0, 100]}, index=dates)
+    result = compute_metrics({"AAA": prices})[0]
+
+    assert result["n_days"] == 2
+    assert np.isfinite(result["cagr"])
+    assert np.isfinite(result["stdev"])
+    assert np.isfinite(result["max_drawdown"])


### PR DESCRIPTION
## Summary
- offload price fetching to threadpool with concurrency limit
- handle HTTP errors from requests and enforce timeout
- sanitize metrics to avoid NaN/inf and expose services package

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1e5e30d2883288d64a44f5e64c84f