### PR TITLE
fix: adjust session management and async utilities

### DIFF
--- a/app/services/fetch_worker.py
+++ b/app/services/fetch_worker.py
@@ -5,12 +5,12 @@ import logging
 from datetime import datetime, date
 from typing import List, Dict, Any, Optional
 
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
 
-from app.api.deps import get_session
+from app.db.engine import create_engine_and_sessionmaker
+from app.core.config import settings
 from app.services.fetch_jobs import (
-    update_job_status, 
+    update_job_status,
     update_job_progress,
     save_job_results,
     get_job_status
@@ -43,135 +43,146 @@ async def process_fetch_job(
         max_concurrency: Maximum concurrent fetches
     """
     logger.info(f"Starting job {job_id} with {len(symbols)} symbols")
-    
-    async for session in get_session():
-        try:
-            # Mark job as processing
-            await update_job_status(
-                session, 
-                job_id, 
-                "processing", 
-                started_at=datetime.utcnow()
-            )
-            
-            # Initialize progress
-            progress = FetchJobProgress(
-                total_symbols=len(symbols),
-                completed_symbols=0,
-                current_symbol=None,
-                total_rows=0,
-                fetched_rows=0,
-                percent=0.0
-            )
-            await update_job_progress(session, job_id, progress)
-            
-            # Process symbols with concurrency control
-            semaphore = asyncio.Semaphore(max_concurrency)
-            results = []
-            
-            async def fetch_single_symbol(symbol: str) -> FetchJobResult:
-                async with semaphore:
-                    try:
-                        # Update current symbol in progress
-                        progress.current_symbol = symbol
-                        await update_job_progress(session, job_id, progress)
-                        
-                        # Fetch data for the symbol
-                        result = await fetch_symbol_data(
-                            symbol=symbol,
-                            date_from=date_from,
-                            date_to=date_to,
-                            interval=interval,
-                            force=force
-                        )
-                        
-                        # Update progress
-                        progress.completed_symbols += 1
-                        progress.fetched_rows += result.rows_fetched
-                        progress.percent = (progress.completed_symbols / progress.total_symbols) * 100.0
-                        progress.current_symbol = None
-                        
-                        await update_job_progress(session, job_id, progress)
-                        
-                        logger.info(f"Completed {symbol}: {result.rows_fetched} rows")
-                        return result
-                        
-                    except Exception as e:
-                        logger.error(f"Failed to fetch {symbol}: {e}")
-                        progress.completed_symbols += 1
-                        progress.percent = (progress.completed_symbols / progress.total_symbols) * 100.0
-                        progress.current_symbol = None
-                        
-                        await update_job_progress(session, job_id, progress)
-                        
-                        return FetchJobResult(
-                            symbol=symbol,
+
+    # 独立したセッションファクトリを作成
+    _, SessionLocal = create_engine_and_sessionmaker(
+        database_url=settings.DATABASE_URL,
+        pool_size=settings.DB_POOL_SIZE,
+        max_overflow=settings.DB_MAX_OVERFLOW,
+        pool_pre_ping=settings.DB_POOL_PRE_PING,
+        pool_recycle=settings.DB_POOL_RECYCLE,
+        echo=settings.DB_ECHO
+    )
+
+    async with SessionLocal() as session:
+        async with session.begin():
+            try:
+                # Mark job as processing
+                await update_job_status(
+                    session,
+                    job_id,
+                    "processing",
+                    started_at=datetime.utcnow()
+                )
+
+                # Initialize progress
+                progress = FetchJobProgress(
+                    total_symbols=len(symbols),
+                    completed_symbols=0,
+                    current_symbol=None,
+                    total_rows=0,
+                    fetched_rows=0,
+                    percent=0.0
+                )
+                await update_job_progress(session, job_id, progress)
+
+                # Process symbols with concurrency control
+                semaphore = asyncio.Semaphore(max_concurrency)
+                results = []
+
+                async def fetch_single_symbol(symbol: str) -> FetchJobResult:
+                    async with semaphore:
+                        try:
+                            # Update current symbol in progress
+                            progress.current_symbol = symbol
+                            await update_job_progress(session, job_id, progress)
+
+                            # Fetch data for the symbol
+                            result = await fetch_symbol_data(
+                                symbol=symbol,
+                                date_from=date_from,
+                                date_to=date_to,
+                                interval=interval,
+                                force=force
+                            )
+
+                            # Update progress
+                            progress.completed_symbols += 1
+                            progress.fetched_rows += result.rows_fetched
+                            progress.percent = (progress.completed_symbols / progress.total_symbols) * 100.0
+                            progress.current_symbol = None
+
+                            await update_job_progress(session, job_id, progress)
+
+                            logger.info(f"Completed {symbol}: {result.rows_fetched} rows")
+                            return result
+
+                        except Exception as e:
+                            logger.error(f"Failed to fetch {symbol}: {e}")
+                            progress.completed_symbols += 1
+                            progress.percent = (progress.completed_symbols / progress.total_symbols) * 100.0
+                            progress.current_symbol = None
+
+                            await update_job_progress(session, job_id, progress)
+
+                            return FetchJobResult(
+                                symbol=symbol,
+                                status="failed",
+                                rows_fetched=0,
+                                error=str(e)
+                            )
+
+                # Execute all fetches concurrently
+                tasks = [fetch_single_symbol(symbol) for symbol in symbols]
+                results = await asyncio.gather(*tasks, return_exceptions=True)
+
+                # Process results and count successes/failures
+                processed_results = []
+                success_count = 0
+                error_count = 0
+
+                for i, result in enumerate(results):
+                    if isinstance(result, Exception):
+                        logger.error(f"Task failed for {symbols[i]}: {result}")
+                        processed_results.append(FetchJobResult(
+                            symbol=symbols[i],
                             status="failed",
                             rows_fetched=0,
-                            error=str(e)
-                        )
-            
-            # Execute all fetches concurrently
-            tasks = [fetch_single_symbol(symbol) for symbol in symbols]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            
-            # Process results and count successes/failures
-            processed_results = []
-            success_count = 0
-            error_count = 0
-            
-            for i, result in enumerate(results):
-                if isinstance(result, Exception):
-                    logger.error(f"Task failed for {symbols[i]}: {result}")
-                    processed_results.append(FetchJobResult(
-                        symbol=symbols[i],
+                            error=str(result)
+                        ))
+                        error_count += 1
+                    else:
+                        processed_results.append(result)
+                        if result.status == "success":
+                            success_count += 1
+                        else:
+                            error_count += 1
+
+                # Save results
+                await save_job_results(session, job_id, processed_results)
+
+                # Mark job as completed
+                final_status = "completed" if error_count == 0 else "completed_with_errors"
+                await update_job_status(
+                    session,
+                    job_id,
+                    final_status,
+                    completed_at=datetime.utcnow()
+                )
+
+                logger.info(f"Job {job_id} completed: {success_count} success, {error_count} errors")
+
+            except Exception as e:
+                logger.error(f"Job {job_id} failed with exception: {e}")
+
+                # Mark job as failed
+                await update_job_status(
+                    session,
+                    job_id,
+                    "failed",
+                    completed_at=datetime.utcnow()
+                )
+
+                # Save error information
+                error_results = [
+                    FetchJobResult(
+                        symbol=symbol,
                         status="failed",
                         rows_fetched=0,
-                        error=str(result)
-                    ))
-                    error_count += 1
-                else:
-                    processed_results.append(result)
-                    if result.status == "success":
-                        success_count += 1
-                    else:
-                        error_count += 1
-            
-            # Save results
-            await save_job_results(session, job_id, processed_results)
-            
-            # Mark job as completed
-            final_status = "completed" if error_count == 0 else "completed_with_errors"
-            await update_job_status(
-                session, 
-                job_id, 
-                final_status,
-                completed_at=datetime.utcnow()
-            )
-            
-            logger.info(f"Job {job_id} completed: {success_count} success, {error_count} errors")
-            
-        except Exception as e:
-            logger.error(f"Job {job_id} failed with exception: {e}")
-            
-            # Mark job as failed
-            await update_job_status(
-                session, 
-                job_id, 
-                "failed",
-                completed_at=datetime.utcnow()
-            )
-            
-            # Save error information
-            error_results = [
-                FetchJobResult(
-                    symbol=symbol,
-                    status="failed",
-                    rows_fetched=0,
-                    error=f"Job failed: {str(e)}"
-                ) for symbol in symbols
-            ]
-            await save_job_results(session, job_id, error_results)
+                        error=f"Job failed: {str(e)}"
+                    ) for symbol in symbols
+                ]
+                await save_job_results(session, job_id, error_results)
 
 
 async def fetch_symbol_data(
@@ -242,23 +253,33 @@ async def fetch_symbol_data(
             }
             rows_to_upsert.append(price_data)
         
-        # Use upsert service to save data
-        async for session in get_session():
-            inserted_count, updated_count = await upsert_prices(
-                session, rows_to_upsert, force_update=force
-            )
-            
-            total_rows = inserted_count + updated_count
-            logger.info(f"Upserted {total_rows} rows for {symbol} ({inserted_count} new, {updated_count} updated)")
-            
-            return FetchJobResult(
-                symbol=symbol,
-                status="success",
-                rows_fetched=total_rows,
-                date_from=date_from,
-                date_to=date_to,
-                error=None
-            )
+        # 独立したセッションを作成（単一タスク用）
+        _, SessionLocal = create_engine_and_sessionmaker(
+            database_url=settings.DATABASE_URL,
+            pool_size=1,
+            max_overflow=0,
+            pool_pre_ping=settings.DB_POOL_PRE_PING,
+            pool_recycle=settings.DB_POOL_RECYCLE,
+            echo=False
+        )
+
+        async with SessionLocal() as session:
+            async with session.begin():
+                inserted_count, updated_count = await upsert_prices(
+                    session, rows_to_upsert, force_update=force
+                )
+
+                total_rows = inserted_count + updated_count
+                logger.info(f"Upserted {total_rows} rows for {symbol} ({inserted_count} new, {updated_count} updated)")
+
+                return FetchJobResult(
+                    symbol=symbol,
+                    status="success",
+                    rows_fetched=total_rows,
+                    date_from=date_from,
+                    date_to=date_to,
+                    error=None
+                )
         
     except ImportError:
         logger.error("yfinance not installed. Install with: pip install yfinance")
@@ -289,31 +310,37 @@ async def get_job_queue_status() -> Dict[str, Any]:
     Returns:
         Dictionary with queue statistics
     """
-    async for session in get_session():
+    _, SessionLocal = create_engine_and_sessionmaker(
+        database_url=settings.DATABASE_URL,
+        pool_size=1,
+        max_overflow=0
+    )
+
+    async with SessionLocal() as session:
         # Count jobs by status
         status_query = """
-        SELECT status, COUNT(*) as count 
-        FROM fetch_jobs 
+        SELECT status, COUNT(*) as count
+        FROM fetch_jobs
         GROUP BY status
         """
-        
+
         result = await session.execute(text(status_query))
         status_counts = {row.status: row.count for row in result.fetchall()}
-        
+
         # Get recent job statistics
         recent_query = """
-        SELECT 
+        SELECT
             COUNT(*) as total_recent,
             COUNT(*) FILTER (WHERE status = 'completed') as completed_recent,
             COUNT(*) FILTER (WHERE status = 'failed') as failed_recent,
             AVG(EXTRACT(EPOCH FROM (completed_at - started_at))) as avg_duration
-        FROM fetch_jobs 
+        FROM fetch_jobs
         WHERE created_at >= NOW() - INTERVAL '24 hours'
         """
-        
+
         result = await session.execute(text(recent_query))
         recent_stats = result.first()
-        
+
         return {
             "status_counts": status_counts,
             "recent_24h": {

--- a/engineering-tasks-20250907.md
+++ b/engineering-tasks-20250907.md
@@ -11,24 +11,24 @@
 
 | タスクID | カテゴリ | ファイル | ステータス | 完了日時 | 検証結果 |
 |----------|----------|----------|------------|----------|----------|
-| FW-001 | Import追加 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-002 | 関数修正1 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-003 | 関数修正2 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-004 | 関数修正3 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-005 | 関数修正4 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-006 | 削除1 | fetch_worker.py | [ ] 未着手 | - | - |
-| FW-007 | 削除2 | fetch_worker.py | [ ] 未着手 | - | - |
-| QR-001 | Import追加 | queries.py | [ ] 未着手 | - | - |
-| QR-002 | 関数作成 | queries.py | [ ] 未着手 | - | - |
-| QR-003 | 関数置換 | queries.py | [ ] 未着手 | - | - |
-| QR-004 | except修正1 | queries.py | [ ] 未着手 | - | - |
-| QR-005 | except修正2 | queries.py | [ ] 未着手 | - | - |
-| PR-001 | 行削除 | prices.py | [ ] 未着手 | - | - |
-| PR-002 | インデント修正 | prices.py | [ ] 未着手 | - | - |
-| VF-001 | Syntax検証 | 全ファイル | [ ] 未着手 | - | - |
-| VF-002 | Import検証 | 全ファイル | [ ] 未着手 | - | - |
-| VF-003 | 起動テスト | Docker | [ ] 未着手 | - | - |
-| VF-004 | APIテスト | エンドポイント | [ ] 未着手 | - | - |
+| FW-001 | Import追加 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-002 | 関数修正1 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-003 | 関数修正2 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-004 | 関数修正3 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-005 | 関数修正4 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-006 | 削除1 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| FW-007 | 削除2 | fetch_worker.py | [x] 完了 | 2025-09-06 | PASS |
+| QR-001 | Import追加 | queries.py | [x] 完了 | 2025-09-06 | PASS |
+| QR-002 | 関数作成 | queries.py | [x] 完了 | 2025-09-06 | PASS |
+| QR-003 | 関数置換 | queries.py | [x] 完了 | 2025-09-06 | PASS |
+| QR-004 | except修正1 | queries.py | [x] 完了 | 2025-09-06 | PASS |
+| QR-005 | except修正2 | queries.py | [x] 完了 | 2025-09-06 | PASS |
+| PR-001 | 行削除 | prices.py | [x] 完了 | 2025-09-06 | PASS |
+| PR-002 | インデント修正 | prices.py | [x] 完了 | 2025-09-06 | PASS |
+| VF-001 | Syntax検証 | 全ファイル | [x] 完了 | 2025-09-06 | PASS |
+| VF-002 | Import検証 | 全ファイル | [x] 完了 | 2025-09-06 | PASS |
+| VF-003 | 起動テスト | Docker | [ ] 未完了 | 2025-09-06 | Docker未インストール |
+| VF-004 | APIテスト | エンドポイント | [ ] 未完了 | 2025-09-06 | サーバ未起動 |
 
 ---
 


### PR DESCRIPTION
## Summary
- use independent SessionLocal factories in background workers
- add async-friendly earliest date lookup using threadpool
- remove redundant transaction handling in price API

## Testing
- `python -m py_compile app/services/fetch_worker.py`
- `python -m py_compile app/db/queries.py`
- `python -m py_compile app/api/v1/prices.py`
- `grep "from app.db.engine import create_engine_and_sessionmaker" app/services/fetch_worker.py`
- `grep "from starlette.concurrency import run_in_threadpool" app/db/queries.py`
- `grep "import logging" app/db/queries.py`
- `docker compose down` *(fails: command not found)*
- `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:8000/healthz` *(returns 000)*


------
https://chatgpt.com/codex/tasks/task_e_68bc547bb46c8328886b82c6fe56888f