### PR TITLE
fix: ensure fetch worker commits data

### DIFF
--- a/app/services/fetch_worker.py
+++ b/app/services/fetch_worker.py
@@ -241,10 +241,14 @@ async def fetch_symbol_data(
         )
 
         async with SessionLocal() as session:
-            # async with session.begin():  # 削除
-            inserted_count, updated_count = await upsert_prices(
-                session, rows_to_upsert, force_update=force
-            )
+            try:
+                inserted_count, updated_count = await upsert_prices(
+                    session, rows_to_upsert, force_update=force
+                )
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
 
             total_rows = inserted_count + updated_count
             logger.info(

--- a/tests/unit/test_fetch_symbol_commit.py
+++ b/tests/unit/test_fetch_symbol_commit.py
@@ -1,0 +1,38 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from datetime import date
+import pandas as pd
+
+
+@pytest.mark.asyncio
+async def test_fetch_symbol_data_commits_transaction():
+    """fetch_symbol_data should commit after upserting prices."""
+    from app.services.fetch_worker import fetch_symbol_data
+
+    # Prepare mock DataFrame returned by yfinance
+    df = pd.DataFrame({
+        "Open": [1.0],
+        "High": [1.0],
+        "Low": [1.0],
+        "Close": [1.0],
+        "Volume": [100],
+    })
+    df.index = pd.DatetimeIndex([pd.Timestamp("2024-01-02")])
+    df.index.name = "Date"
+
+    with patch("yfinance.Ticker") as mock_ticker, \
+         patch("app.services.fetch_worker.create_engine_and_sessionmaker") as mock_engine, \
+         patch("app.services.upsert.upsert_prices", new=AsyncMock(return_value=(1, 0))):
+        mock_ticker.return_value.history.return_value = df
+
+        mock_session = AsyncMock()
+        mock_session.commit = AsyncMock()
+        mock_session.rollback = AsyncMock()
+        session_ctx = AsyncMock()
+        session_ctx.__aenter__.return_value = mock_session
+        mock_engine.return_value = (None, lambda: session_ctx)
+
+        result = await fetch_symbol_data("AAPL", date(2024, 1, 1), date(2024, 1, 31))
+
+        mock_session.commit.assert_awaited()
+        assert result.status == "success"


### PR DESCRIPTION
## Summary
- commit and rollback transactions in `fetch_symbol_data`
- add unit test to verify fetch worker commits the session

## Testing
- `pytest tests/unit/test_fetch_symbol_commit.py tests/unit/test_fetch_worker_transaction.py tests/unit/test_date_boundary.py -q`
- `pytest` *(fails: integration CSV export, Fetch API tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc754b2c9083289873b4944ff7c76e